### PR TITLE
libplatsupport: Use 180 degree phase feedback for spi on exynos

### DIFF
--- a/libplatsupport/src/mach/exynos/spi.c
+++ b/libplatsupport/src/mach/exynos/spi.c
@@ -204,7 +204,7 @@ spi_config(spi_bus_t *spi_bus)
      * The feedback clock only works in the master mode.
      */
     if (spi_bus->mode == MASTER_MODE) {
-        v = (0x0 << FB_CLK_SEL_SHF);
+        v = (0x2 << FB_CLK_SEL_SHF);
         spi_bus->regs->fb_clk_sel = v;
     }
 


### PR DESCRIPTION
The comment in the code says to use a 180 degree phase feedback,
but the code was using no feedback clock. This commit changes the
code to match the comment (and fixes a bug we were experiencing on
the HACMS program).