### PR TITLE
Zync-7000 UART: Use status register to check if RX fifo is non-empty

### DIFF
--- a/libplatsupport/src/plat/zynq7000/serial.c
+++ b/libplatsupport/src/plat/zynq7000/serial.c
@@ -187,7 +187,7 @@ int uart_getchar(ps_chardevice_t *d)
     zynq7000_uart_regs_t* regs = zynq7000_uart_get_priv(d);
     int c = -1;
 
-    if ((regs->sr & UART_SR_RTRIG) || (regs->isr & UART_ISR_TIMEOUT)) {
+    if (!(regs->sr & UART_SR_REMPTY)) {
         c = regs->fifo;
 
         /* Clear the Rx timeout interrupt status bit if set */


### PR DESCRIPTION
The QEMU emulator for Zync-7000 appears to have a bug makes it appear
like the UART timeout interrupt has fired even if the interrupt is
disabled. This causes the libplatsupport driver to make a read even
when no data is available (returning 0x00). This patch changes the
reading guard to check the status register directly rather than
checking interrupts. This works correctly under QEMU and should
continue to work on the actual hardware.