### PR TITLE
libplatsupport: Rename uart_configure to serial_configure to match serial.h declaration

### DIFF
--- a/libplatsupport/src/plat/imx6/serial.c
+++ b/libplatsupport/src/plat/imx6/serial.c
@@ -135,7 +135,7 @@ imx6_uart_set_baud(ps_chardevice_t* d, long bps)
 }
 
 int
-uart_configure(ps_chardevice_t* d, long bps, int char_size, enum serial_parity parity, int stop_bits)
+serial_configure(ps_chardevice_t* d, long bps, int char_size, enum serial_parity parity, int stop_bits)
 {
     imx6_uart_regs_t* regs = imx6_uart_get_priv(d);
     uint32_t cr2;
@@ -208,7 +208,7 @@ int uart_init(const struct dev_defn* defn,
     while (!(regs->cr2 & UART_CR2_SRST));
 
     /* Line configuration */
-    uart_configure(dev, 115200, 8, PARITY_NONE, 1);
+    serial_configure(dev, 115200, 8, PARITY_NONE, 1);
 
     /* Enable the UART */
     regs->cr1 |= UART_CR1_UARTEN;                /* Enable The uart.                  */

--- a/libplatsupport/src/plat/tk1/serial.c
+++ b/libplatsupport/src/plat/tk1/serial.c
@@ -521,7 +521,7 @@ tk1_uart_get_divisor_for(int baud)
 }
 
 int
-uart_configure(ps_chardevice_t* d, long bps, int char_size, enum serial_parity parity, int stop_bits)
+serial_configure(ps_chardevice_t* d, long bps, int char_size, enum serial_parity parity, int stop_bits)
 {
     tk1_uart_regs_t* regs = tk1_uart_get_priv(d);
     int divisor;
@@ -661,7 +661,7 @@ tk1_uart_init_common(const struct dev_defn *defn, void *const uart_mmio_vaddr,
     tk1_uart_set_thr_irq(regs, false);
 
     /* Line configuration */
-    uart_configure(dev, 115200, 8, PARITY_NONE, 1);
+    serial_configure(dev, 115200, 8, PARITY_NONE, 1);
 
     /* Set FCR[0] to 1 to enable FIFO mode, and enable DMA mode 1 which will
      * generate an interrupt only when the buffer has.

--- a/libplatsupport/src/plat/zynq7000/serial.c
+++ b/libplatsupport/src/plat/zynq7000/serial.c
@@ -329,7 +329,7 @@ zynq7000_uart_set_baud(ps_chardevice_t* d, long bps)
 }
 
 int
-uart_configure(ps_chardevice_t* d, long bps, int char_size, enum serial_parity parity, int stop_bits)
+serial_configure(ps_chardevice_t* d, long bps, int char_size, enum serial_parity parity, int stop_bits)
 {
     zynq7000_uart_regs_t* regs = zynq7000_uart_get_priv(d);
     uint32_t mr;
@@ -409,7 +409,7 @@ int uart_init(const struct dev_defn* defn,
     // TODO - does the I/O signal routing have to be configured here too?
 
     /* Configure UART character frame */
-    uart_configure(dev, 115200, 8, PARITY_NONE, 1);
+    serial_configure(dev, 115200, 8, PARITY_NONE, 1);
 
     /* Set the level of the RxFIFO trigger level */
     regs->rxwm &= ~UART_RXWM_RTRIG_MASK;    /* Clear the Rx trigger level */


### PR DESCRIPTION
serial.h declares serial_configure, but some of the serial drivers call this function uart_configure.

  https://github.com/seL4/util_libs/blob/master/libplatsupport/include/platsupport/serial.h#L52