### PR TITLE
Fixed warnings found by clang

### DIFF
--- a/libplatsupport/src/arch/arm/clock.c
+++ b/libplatsupport/src/arch/arm/clock.c
@@ -44,7 +44,7 @@ _fixed_clk_init(clk_t* clk)
 freq_t
 _default_clk_get_freq(clk_t* clk)
 {
-    assert(clk->id >= 0 && clk->id < NCLOCKS);
+    assert(clk->id < NCLOCKS);
     return ps_freq_default[clk->id];
 }
 
@@ -69,7 +69,7 @@ _default_clk_init(clk_t* clk)
 static clk_t*
 get_clock_default(clock_sys_t* clock_sys UNUSED, enum clk_id id)
 {
-    if (id < 0 || id >= NCLOCKS) {
+    if (id >= NCLOCKS) {
         return NULL;
     } else {
         clk_t* clk;
@@ -104,7 +104,7 @@ clock_sys_init_default(clock_sys_t* clock_sys)
 int
 clock_sys_set_default_freq(enum clk_id id, freq_t hz)
 {
-    if (id < 0 || id >= NCLOCKS) {
+    if (id >= NCLOCKS) {
         return -1;
     } else {
         ps_freq_default[id] = hz;
@@ -115,7 +115,7 @@ clock_sys_set_default_freq(enum clk_id id, freq_t hz)
 clk_t*
 ps_get_clock(clock_sys_t* sys, enum clk_id id)
 {
-    if (id < 0 || id >= NCLOCKS) {
+    if (id >= NCLOCKS) {
         return NULL;
     } else {
         clk_t* clk;

--- a/libutils/include/utils/attribute.h
+++ b/libutils/include/utils/attribute.h
@@ -63,7 +63,7 @@
 #define SENTINEL_LAST __attribute__((sentinel))
 #define UNUSED       __attribute__((__unused__))
 #define USED         __attribute__((__used__))
-#if __clang__ && !__has_attribute(externally_visible)
+#if defined(__clang__) && !__has_attribute(externally_visible)
   #define VISIBLE /* ignored */
 #else
   #define VISIBLE __attribute__((__externally_visible__))


### PR DESCRIPTION
~/seL4test/libs/libplatsupport/src/arch/arm/clock.c:45:22: warning: comparison of unsigned enum expression >= 0 is always true [-Wtautological-compare]
    ((void)((clk->id >= 0 && clk->id < NCLOCKS) || (__assert_fail("clk->id >= 0 && clk->id < NCLOCKS", "~/seL4test/libs/libplatsupport/src/arch/arm/clock.c", 45, __func__),0)));
             ~~~~~~~ ^  ~
~/seL4test/libs/libplatsupport/src/arch/arm/clock.c:70:12: warning: comparison of unsigned enum expression < 0 is always false [-Wtautological-compare]
    if (id < 0 || id >= NCLOCKS) {
        ~~ ^ ~
~/seL4test/libs/libplatsupport/src/arch/arm/clock.c:105:12: warning: comparison of unsigned enum expression < 0 is always false [-Wtautological-compare]
    if (id < 0 || id >= NCLOCKS) {
        ~~ ^ ~
~/seL4test/libs/libplatsupport/src/arch/arm/clock.c:116:12: warning: comparison of unsigned enum expression < 0 is always false [-Wtautological-compare]
    if (id < 0 || id >= NCLOCKS) {
        ~~ ^ ~
4 warnings generated.