### PR TITLE
Fixed memory initialization for preallocated RX ring buffer

### DIFF
--- a/libethdrivers/src/lwip.c
+++ b/libethdrivers/src/lwip.c
@@ -449,6 +449,10 @@ lwip_iface_t *ethif_new_lwip_driver_no_malloc(ps_io_ops_t io_ops, ps_dma_man_t *
     /* if the driver did not already cause it to happen, allocate the preallocated buffers */
     if (!pbuf_dma && !iface->bufs) {
         initialize_free_bufs(iface);
+        if (iface->bufs == NULL) {
+            LOG_ERROR("Fault preallocating bufs");
+            goto error;
+        }
     }
     iface->ethif_init = ethif_init;
     return iface;

--- a/libethdrivers/src/plat/imx6/imx6.c
+++ b/libethdrivers/src/plat/imx6/imx6.c
@@ -51,7 +51,7 @@ struct imx6_eth_data {
     volatile struct descriptor *rx_ring;
     unsigned int rx_size;
     unsigned int tx_size;
-    struct dma_buf_cookie *rx_cookies;
+    void **rx_cookies;                   // Array (of rx_size elements) of type 'void *'
     unsigned int rx_remain;
     unsigned int tx_remain;
     void **tx_cookies;
@@ -103,17 +103,18 @@ static void fill_rx_bufs(struct eth_driver *driver) {
     __sync_synchronize();
     while (dev->rx_remain > 0) {
         /* request a buffer */
-        struct dma_buf_cookie cookie_bufs;
-        void *cookie = &cookie_bufs;
+        void *cookie = NULL;
         int next_rdt = (dev->rdt + 1) % dev->rx_size;
+
+        // This fn ptr is either lwip_allocate_rx_buf or lwip_pbuf_allocate_rx_buf (in src/lwip.c)
         uintptr_t phys = driver->i_cb.allocate_rx_buf(driver->cb_cookie, BUF_SIZE, &cookie);
         if (!phys) {
+            // NOTE: This condition could happen if 
+            //       CONFIG_LIB_ETHDRIVER_NUM_PREALLOCATED_BUFFERS < CONFIG_LIB_ETHDRIVER_RX_DESC_COUNT
             break;
         }
 
-        dev->rx_cookies[dev->rdt].vbuf = cookie_bufs.vbuf;
-        dev->rx_cookies[dev->rdt].pbuf = cookie_bufs.pbuf;
-
+        dev->rx_cookies[dev->rdt] = cookie;
         dev->rx_ring[dev->rdt].phys = phys;
         dev->rx_ring[dev->rdt].len = 0;
 
@@ -175,7 +176,7 @@ static int initialize_desc_ring(struct imx6_eth_data *dev, ps_dma_man_t *dma_man
     }
     ps_dma_cache_clean_invalidate(dma_man, rx_ring.virt, sizeof(struct descriptor) * dev->rx_size);
     ps_dma_cache_clean_invalidate(dma_man, tx_ring.virt, sizeof(struct descriptor) * dev->tx_size);
-    dev->rx_cookies = malloc(sizeof(struct dma_buf_cookie) * dev->rx_size);
+    dev->rx_cookies = malloc(sizeof(void*) * dev->rx_size);
     dev->tx_cookies = malloc(sizeof(void*) * dev->tx_size);
     dev->tx_lengths = malloc(sizeof(unsigned int) * dev->tx_size);
     if (!dev->rx_cookies || !dev->tx_cookies || !dev->tx_lengths) {
@@ -232,7 +233,7 @@ static void complete_rx(struct eth_driver *eth_driver) {
             /* not complete yet */
             break;
         }
-        void *cookie = &dev->rx_cookies[dev->rdh];
+        void *cookie = dev->rx_cookies[dev->rdh];
         unsigned int len = dev->rx_ring[dev->rdh].len;
         /* update rdh */
         dev->rdh = (dev->rdh + 1) % dev->rx_size;

--- a/liblwip/include/lwip/arch/cc.h
+++ b/liblwip/include/lwip/arch/cc.h
@@ -22,6 +22,8 @@ typedef uintptr_t mem_ptr_t;
 #define SZT_F "uz"
 
 
+// BYTE_ORDER might be defined by the architecture
+#ifndef BYTE_ORDER
 #if defined(__BYTE_ORDER__)
 #  define BYTE_ORDER __BYTE_ORDER__
 #elif defined(__BIG_ENDIAN)
@@ -30,6 +32,7 @@ typedef uintptr_t mem_ptr_t;
 #  define BYTE_ORDER LITTLE_ENDIAN
 #else
 #  error Unable to detemine system endianess
+#endif
 #endif
 
 


### PR DESCRIPTION
RX Ring buffer (rx_cookie) was corrupt and uninitialized causing the system to throw an invalid memory access violation when a new packet was received from the iMX6 ethernet controller.

Fix change the definition of the rx_cookie to be a void * where the actual buffer and meaning is delegated to the file that interface with the stack (in my case I'm using lwip.c).

See commit comments for additional info