### PR TITLE
libplatsupport: add missing 3rd parameter to zynq_mux_feature_enable()

### DIFF
--- a/libplatsupport/src/mach/zynq/mux.c
+++ b/libplatsupport/src/mach/zynq/mux.c
@@ -37,7 +37,8 @@ static inline void set_mux_priv(mux_sys_t* mux, struct zynq_mux* zynq_mux)
 }
 
 static int
-zynq_mux_feature_enable(mux_sys_t* mux, enum mux_feature mux_feature)
+zynq_mux_feature_enable(mux_sys_t* mux, enum mux_feature mux_feature,
+                        UNUSED enum mux_gpio_dir mgd)
 {
     return 0;
 }


### PR DESCRIPTION
The signature of feature_enable() changed to take a 3rd parameter, but this has never been updated here. Adding the parameter prevents a compiler warning.