### PR TITLE
Use DMA Buffer Structure for allocating RX Buffers.

### DIFF
--- a/libethdrivers/src/plat/zynq7000/uboot/zynq_gem.c
+++ b/libethdrivers/src/plat/zynq7000/uboot/zynq_gem.c
@@ -26,9 +26,6 @@
 #include <platsupport/clock.h>
 #include <platsupport/io.h>
 
-#include <sel4utils/page_dma.h>
-#include <sel4platsupport/io.h>
-
 #include <malloc.h>
 #include <errno.h>
 


### PR DESCRIPTION
This method is used in the zynq7000 ethernet driver
instead of a void pointer. While testing on the lastest
release, DornerWorks noticed that the imx6 would pass a
NULL pointer to the Ethdriver component, which was not
behavior noticed in previous releases.