### PR TITLE
Generic timer

### DIFF
--- a/libplatsupport/CMakeLists.txt
+++ b/libplatsupport/CMakeLists.txt
@@ -71,4 +71,7 @@ target_include_directories(
 if(NOT "${KernelArmMach}" STREQUAL "")
     target_include_directories(platsupport PUBLIC mach_include/${KernelArmMach})
 endif()
+if("${KernelArch}" STREQUAL "arm")
+    target_include_directories(platsupport PUBLIC sel4_arch_include/${KernelSel4Arch})
+endif()
 target_link_libraries(platsupport Configuration muslc utils)

--- a/libplatsupport/CMakeLists.txt
+++ b/libplatsupport/CMakeLists.txt
@@ -69,7 +69,6 @@ if(KernelPlatImx6 OR KernelPlatformImx7Sabre OR KernelPlatformKZM OR KernelPlatf
     endif()
 endif()
 
-
 list(SORT deps)
 
 add_config_library(platsupport "${configure_string}")

--- a/libplatsupport/CMakeLists.txt
+++ b/libplatsupport/CMakeLists.txt
@@ -37,10 +37,22 @@ file(
         deps
         src/mach/${KernelArmMach}/*.c
         src/plat/${KernelPlatform}/*.c
-        src/arch/${KernelArch}/*.c
         src/*.c
         src/plat/${KernelPlatform}/acpi/*.c
 )
+
+if(${KernelArch} STREQUAL "arm")
+    list(APPEND deps src/arch/arm/clock.c)
+    list(APPEND deps src/arch/arm/delay.c)
+    list(APPEND deps src/arch/arm/dma330.c)
+    list(APPEND deps src/arch/arm/i2c.c)
+    list(APPEND deps src/arch/arm/i2c_bitbang.c)
+    list(APPEND deps src/arch/arm/mux.c)
+    list(APPEND deps src/arch/arm/generic_timer.c)
+elseif(${KernelArch} STREQUAL "x86")
+    list(APPEND deps src/arch/x86/delay.c)
+    list(APPEND deps src/arch/x86/tsc.c)
+endif()
 
 if(KernelPlatformExynos5422)
     list(APPEND deps src/mach/${KernelArmMach}/clock/exynos_5422_clock.c)

--- a/libplatsupport/arch_include/arm/platsupport/arch/generic_timer.h
+++ b/libplatsupport/arch_include/arm/platsupport/arch/generic_timer.h
@@ -18,12 +18,8 @@
 
 /*
  * This timer will only work if the kernel has configured
- * CNTPCT to be read from user-level. This is done by writing 1 to CNTKCTL.
- * If CONFIG_DANGEROUS_CODE_INJECTION is available, we'll try that,
- * otherwise we will use a default frequency.
- *
- * If all else fails the timer will fail to initialise.
- *
+ * CNTPCT to be read from user-level. This is done by setting CONFIG_EXPORT_PCNT_USER in
+ * a kernel configuration.
  */
 typedef struct {
     uint32_t freq;

--- a/libplatsupport/arch_include/arm/platsupport/arch/generic_timer.h
+++ b/libplatsupport/arch_include/arm/platsupport/arch/generic_timer.h
@@ -16,7 +16,6 @@
 #include <autoconf.h>
 
 
-#ifdef CONFIG_EXPORT_PCNT_USER
 typedef struct {
     uint32_t freq;
 } generic_timer_t;
@@ -31,5 +30,3 @@ get_generic_timer_properties(void) {
 
 int generic_timer_init(generic_timer_t *timer);
 uint64_t generic_timer_get_time(generic_timer_t *timer);
-
-#endif /* CONFIG_EXPORT_PCNT_USER */

--- a/libplatsupport/arch_include/arm/platsupport/arch/generic_timer.h
+++ b/libplatsupport/arch_include/arm/platsupport/arch/generic_timer.h
@@ -12,9 +12,13 @@
 
 #pragma once
 
+#include <platsupport/sel4_arch/util.h>
 #include <platsupport/timer.h>
 #include <autoconf.h>
 
+#define GENERIC_TIMER_ENABLE BIT(0)
+#define GENERIC_TIMER_IMASK  BIT(1)
+#define GENERIC_TIMER_STATUS BIT(2)
 
 /*
  * This timer will only work if the kernel has configured
@@ -31,6 +35,74 @@ get_generic_timer_properties(void) {
         .upcounter = true,
         .bit_width = 64
     };
+}
+
+static inline uint64_t generic_timer_get_ticks(void)
+{
+    uint64_t time;
+    COPROC_READ_64(CNTPCT, time);
+    return time;
+}
+
+static inline void generic_timer_set_compare(uint64_t ticks)
+{
+    COPROC_WRITE_64(CNTP_CVAL, ticks);
+}
+
+static inline uint32_t generic_timer_get_freq(void)
+{
+    uintptr_t freq;
+    COPROC_READ_WORD(CNTFRQ, freq);
+    return (uint32_t) freq;
+}
+
+static inline uint32_t generic_timer_read_ctrl(void)
+{
+    uintptr_t ctrl;
+    COPROC_READ_WORD(CNTP_CTL, ctrl);
+    return ctrl;
+}
+
+static inline void generic_timer_write_ctrl(uintptr_t ctrl)
+{
+    COPROC_WRITE_WORD(CNTP_CTL, ctrl);
+}
+
+static inline void generic_timer_or_ctrl(uintptr_t bits)
+{
+    uintptr_t ctrl = generic_timer_read_ctrl();
+    generic_timer_write_ctrl(ctrl | bits);
+}
+
+static inline void generic_timer_and_ctrl(uintptr_t bits)
+{
+    uintptr_t ctrl = generic_timer_read_ctrl();
+    generic_timer_write_ctrl(ctrl & bits);
+}
+
+static inline void generic_timer_enable(void)
+{
+    generic_timer_or_ctrl(GENERIC_TIMER_ENABLE);
+}
+
+static inline void generic_timer_disable(void)
+{
+    generic_timer_and_ctrl(~GENERIC_TIMER_ENABLE);
+}
+
+static inline void generic_timer_unmask_irq(void)
+{
+    generic_timer_and_ctrl(~GENERIC_TIMER_IMASK);
+}
+
+static inline void generic_timer_mask_irq(void)
+{
+    generic_timer_or_ctrl(GENERIC_TIMER_IMASK);
+}
+
+static inline uintptr_t generic_timer_status(void)
+{
+    return generic_timer_read_ctrl() & GENERIC_TIMER_STATUS;
 }
 
 int generic_timer_init(generic_timer_t *timer);

--- a/libplatsupport/arch_include/arm/platsupport/arch/generic_timer.h
+++ b/libplatsupport/arch_include/arm/platsupport/arch/generic_timer.h
@@ -16,6 +16,15 @@
 #include <autoconf.h>
 
 
+/*
+ * This timer will only work if the kernel has configured
+ * CNTPCT to be read from user-level. This is done by writing 1 to CNTKCTL.
+ * If CONFIG_DANGEROUS_CODE_INJECTION is available, we'll try that,
+ * otherwise we will use a default frequency.
+ *
+ * If all else fails the timer will fail to initialise.
+ *
+ */
 typedef struct {
     uint32_t freq;
 } generic_timer_t;

--- a/libplatsupport/sel4_arch_include/aarch32/platsupport/sel4_arch/util.h
+++ b/libplatsupport/sel4_arch_include/aarch32/platsupport/sel4_arch/util.h
@@ -1,0 +1,40 @@
+/*
+* Copyright 2019, Data61
+* Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+* ABN 41 687 119 230.
+*
+* This software may be distributed and modified according to the terms of
+* the BSD 2-Clause license. Note that NO WARRANTY is provided.
+* See "LICENSE_BSD2.txt" for details.
+*
+* @TAG(DATA61_BSD)
+*/
+
+#pragma once
+
+#define MCR(cpreg, v)                               \
+    do {                                            \
+        uint32_t _v = v;                            \
+        asm volatile("mcr  " cpreg :: "r" (_v));    \
+    } while(0)
+#define MCRR(cpreg,v)                               \
+    do {                                            \
+        uint64_t _v = v;                            \
+        asm volatile("mcrr  " cpreg :: "r" (_v));     \
+    } while (0)
+#define MRRC(cpreg, v)  asm volatile("mrrc " cpreg :  "=r"(v))
+#define MRC(cpreg, v)  asm volatile("mrc   " cpreg :  "=r"(v))
+
+#define COPROC_WRITE_WORD(R,W) MCR(R,W)
+#define COPROC_READ_WORD(R,W)  MRC(R,W)
+#define COPROC_WRITE_64(R,W)   MCRR(R,W)
+#define COPROC_READ_64(R,W)    MRRC(R,W)
+
+/* control reigster for the el1 physical timer */
+#define CNTP_CTL  " p15, 0,  %0, c14,  c2, 1"
+/* holds the compare value for the el1 physical timer */
+#define CNTP_CVAL " p15, 2, %Q0, %R0, c14   "
+/* holds the 64-bit physical count value */
+#define CNTPCT    " p15, 0, %Q0, %R0, c14" /* 64-bit RO Physical Count register */
+/* frequency of the timer */
+#define CNTFRQ    " p15, 0,  %0, c14,  c0, 0" /* 32-bit RW Counter Frequency register */

--- a/libplatsupport/sel4_arch_include/aarch64/platsupport/sel4_arch/util.h
+++ b/libplatsupport/sel4_arch_include/aarch64/platsupport/sel4_arch/util.h
@@ -1,0 +1,27 @@
+/*
+* Copyright 2019, Data61
+* Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+* ABN 41 687 119 230.
+*
+* This software may be distributed and modified according to the terms of
+* the BSD 2-Clause license. Note that NO WARRANTY is provided.
+* See "LICENSE_BSD2.txt" for details.
+*
+* @TAG(DATA61_BSD)
+*/
+
+#pragma once
+
+#define COPROC_WRITE_WORD(R,W) asm volatile ("msr " R  ", %0" :: "r"(W))
+#define COPROC_READ_WORD(R,W)  asm volatile ("mrs %0, " R : "=r" (W))
+#define COPROC_WRITE_64(R,W)   COPROC_WRITE_WORD(R,W)
+#define COPROC_READ_64(R,W)    COPROC_READ_WORD(R,W)
+
+/* control reigster for the el1 physical timer */
+#define CNTP_CTL "cntp_ctl_el0"
+/* holds the compare value for the el1 physical timer */
+#define CNTP_CVAL "cntp_cval_el0"
+/* holds the 64-bit physical count value */
+#define CNTPCT "cntpct_el0"
+/* frequency of the timer */
+#define CNTFRQ "cntfrq_el0"

--- a/libplatsupport/src/arch/arm/generic_ltimer.c
+++ b/libplatsupport/src/arch/arm/generic_ltimer.c
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2019, Data61
+ * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+ * ABN 41 687 128 230.
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(DATA61_BSD)
+ */
+#include <autoconf.h>
+#include <stdio.h>
+#include <assert.h>
+
+#include <utils/util.h>
+#include <utils/time.h>
+#include <utils/frequency.h>
+
+#include <platsupport/ltimer.h>
+#include <platsupport/arch/generic_timer.h>
+#include <platsupport/io.h>
+#include <platsupport/plat/timer.h>
+
+typedef struct {
+    uint32_t freq; // frequency of the generic timer
+    uint64_t period; // period of a current periodic timeout, in ns
+    ps_io_ops_t ops;
+} generic_ltimer_t;
+
+static size_t get_num_irqs(void *data)
+{
+    return 1;
+}
+
+static int get_nth_irq(void *data, size_t n, ps_irq_t *irq)
+{
+    assert(n < get_num_irqs(data));
+    irq->type = PS_INTERRUPT;
+    irq->irq.number = GENERIC_TIMER_PCNT_IRQ;
+    return 0;
+}
+
+static size_t get_num_pmems(void *data)
+{
+    return 0;
+}
+
+static int get_nth_pmem(void *data, size_t n, pmem_region_t *region)
+{
+    return -1;
+}
+
+static int get_time(void *data, uint64_t *time)
+{
+    assert(data != NULL);
+    assert(time != NULL);
+
+    generic_ltimer_t *ltimer = data;
+    uint64_t ticks = generic_timer_get_ticks();
+    *time = freq_cycles_and_hz_to_ns(ticks, ltimer->freq);
+    return 0;
+}
+
+int set_timeout(void *data, uint64_t ns, timeout_type_t type)
+{
+    generic_ltimer_t *ltimer = data;
+    if (type == TIMEOUT_PERIODIC) {
+        ltimer->period = ns;
+    } else {
+        ltimer->period = 0;
+    }
+
+    uint64_t time;
+    int error = get_time(data, &time);
+    if (type != TIMEOUT_ABSOLUTE) {
+        if (error) {
+            return error;
+        }
+        ns += time;
+    }
+
+    if (time > ns) {
+        return ETIME;
+    }
+    generic_timer_set_compare(freq_ns_and_hz_to_cycles(ns, ltimer->freq));
+
+    return 0;
+}
+
+int handle_irq(void *data, ps_irq_t *irq)
+{
+    if (irq->irq.number != GENERIC_TIMER_PCNT_IRQ) {
+        return EINVAL;
+    }
+
+    generic_ltimer_t *ltimer = data;
+    if (ltimer->period) {
+        set_timeout(data, ltimer->period, TIMEOUT_RELATIVE);
+    } else {
+        generic_timer_set_compare(0);
+    }
+    return 0;
+}
+
+static int get_resolution(void *data, uint64_t *resolution)
+{
+    return ENOSYS;
+}
+
+static int reset(void *data)
+{
+    generic_ltimer_t *generic_ltimer = data;
+    generic_ltimer->period = 0;
+    generic_timer_set_compare(0);
+    return 0;
+}
+
+static void destroy(void *data)
+{
+    UNUSED int error;
+    generic_ltimer_t *generic_ltimer = data;
+    generic_timer_disable();
+    ps_free(&generic_ltimer->ops.malloc_ops, sizeof(generic_ltimer), generic_ltimer);
+}
+
+int ltimer_default_init(ltimer_t *ltimer, ps_io_ops_t ops)
+{
+    if (ltimer == NULL) {
+        ZF_LOGE("ltimer cannot be NULL");
+        return EINVAL;
+    }
+
+    if (!config_set(CONFIG_EXPORT_PCNT_USER)) {
+        ZF_LOGE("Generic timer not exported!");
+        return ENXIO;
+    }
+
+    ltimer_default_describe(ltimer, ops);
+    ltimer->handle_irq = handle_irq;
+    ltimer->get_time = get_time;
+    ltimer->get_resolution = get_resolution;
+    ltimer->set_timeout = set_timeout;
+    ltimer->reset = reset;
+    ltimer->destroy = destroy;
+
+    int error = ps_calloc(&ops.malloc_ops, 1, sizeof(generic_ltimer_t), &ltimer->data);
+    if (error) {
+        return error;
+    }
+    assert(ltimer->data != NULL);
+    generic_ltimer_t *generic_ltimer = ltimer->data;
+
+    generic_ltimer->freq = generic_timer_get_freq();
+    if (generic_ltimer->freq == 0) {
+        ZF_LOGE("Couldn't read timer frequency");
+        error = ENXIO;
+    } else {
+        generic_ltimer->ops = ops;
+        generic_timer_enable();
+    }
+
+    /* if there was an error, clean up */
+    if (error) {
+        ZF_LOGE("Failed to initialise generic timer");
+        destroy(ltimer->data);
+    }
+    return error;
+}
+
+int ltimer_default_describe(ltimer_t *ltimer, ps_io_ops_t ops)
+{
+    if (ltimer == NULL) {
+        ZF_LOGE("Timer is NULL!");
+        return EINVAL;
+    }
+
+    ltimer->get_num_irqs = get_num_irqs;
+    ltimer->get_nth_irq = get_nth_irq;
+    ltimer->get_num_pmems = get_num_pmems;
+    ltimer->get_nth_pmem = get_nth_pmem;
+    return 0;
+}

--- a/libplatsupport/src/arch/arm/generic_timer.c
+++ b/libplatsupport/src/arch/arm/generic_timer.c
@@ -19,8 +19,6 @@
 
 #include <platsupport/arch/generic_timer.h>
 
-#ifdef CONFIG_EXPORT_PCNT_USER
-
 /*
  * This timer will only work if the kernel has configured
  * CNTPCT to be read from user-level. This is done by writing 1 to CNTKCTL.
@@ -61,6 +59,10 @@ int generic_timer_get_init(generic_timer_t *timer)
     }
 
     timer->freq = 0;
+    if (!config_set(CONFIG_EXPORT_PCNT_USER)) {
+        ZF_LOGE("Generic timer not exported!");
+        return ENXIO;
+    }
 
     /* try to read the frequency */
     MRC(CNTFRQ, timer->freq);
@@ -79,4 +81,3 @@ int generic_timer_get_init(generic_timer_t *timer)
 
     return 0;
 }
-#endif /* CONFIG_EXPORT_PCNT_USER */

--- a/libplatsupport/src/arch/arm/generic_timer.c
+++ b/libplatsupport/src/arch/arm/generic_timer.c
@@ -19,15 +19,6 @@
 
 #include <platsupport/arch/generic_timer.h>
 
-/*
- * This timer will only work if the kernel has configured
- * CNTPCT to be read from user-level. This is done by writing 1 to CNTKCTL.
- * If CONFIG_DANGEROUS_CODE_INJECTION is available, we'll try that,
- * otherwise we will use a default frequency.
- *
- * If all else fails the timer will fail to initialise.
- *
- */
 #define MCR(cpreg, v)                               \
     do {                                            \
         uint32_t _v = v;                            \


### PR DESCRIPTION
Update generic timer to work for aarch64 as well as aarch32.

Add a generic timer ltimer implementation which can be included for platforms. 