### PR TITLE
CR LF fix, remove warning and general improvements

### DIFF
--- a/libplatsupport/arch_include/arm/platsupport/clock.h
+++ b/libplatsupport/arch_include/arm/platsupport/clock.h
@@ -32,8 +32,9 @@ enum clock_gate_mode {
 };
 
 struct clock_sys {
-    clk_t* (*get_clock)(clock_sys_t* clock_sys, enum clk_id id);
-    int (*gate_enable)(clock_sys_t* clock_sys, enum clock_gate gate, enum clock_gate_mode mode);
+    clk_t* (*get_clock)(const clock_sys_t* clock_sys, enum clk_id id);
+    int (*gate_enable)(const clock_sys_t* clock_sys, enum clock_gate gate,
+                       enum clock_gate_mode mode);
     void* priv;
 };
 
@@ -56,12 +57,12 @@ struct clock {
     clk_t* child;
     /* Changing parents and initialisation requires access to the clock
      * subsystem. A reference is stored here for convenience */
-    clock_sys_t* clk_sys;
+    const clock_sys_t* clk_sys;
     /// Clock specific functions
     clk_t* (*init)(clk_t* clk);
-    freq_t (*get_freq)(clk_t*);
-    freq_t (*set_freq)(clk_t*, freq_t hz);
-    void (*recal)(clk_t*);
+    freq_t (*get_freq)(const clk_t*);
+    freq_t (*set_freq)(const clk_t*, freq_t hz);
+    void (*recal)(const clk_t*);
 };
 
 /**
@@ -82,7 +83,7 @@ static inline int clock_sys_valid(const clock_sys_t* clock_sys)
  *                       to the clocking subsystem
  * @return               0 on success
  */
-int clock_sys_init(ps_io_ops_t* io_ops, clock_sys_t* clock_sys);
+int clock_sys_init(const ps_io_ops_t* io_ops, clock_sys_t* clock_sys);
 
 /**
  * Initialise a clock subsystem that does not support clock configuration
@@ -113,20 +114,18 @@ int clock_sys_set_default_freq(enum clk_id id, freq_t hz);
  * @return               On success, a handle to the acquired clock.
  *                       Otherwise, NULL.
  */
-static inline clk_t* clk_get_clock(clock_sys_t* clock_sys, enum clk_id id)
+static inline clk_t* clk_get_clock(const clock_sys_t* clock_sys, enum clk_id id)
 {
-    clk_t * clk;
     assert(clock_sys);
     assert(clock_sys->get_clock);
-    clk = clock_sys->get_clock(clock_sys, id);
-    return clk;
+    return clock_sys->get_clock(clock_sys, id);
 };
 
 /**
  * prints a list of initialised clocks
  * @param[in] clock_sys  A handle to the clock subsystem
  */
-void clk_print_clock_tree(clock_sys_t* clock_sys);
+void clk_print_clock_tree(const clock_sys_t* clock_sys);
 
 /**
  * Configure the gating mode of a clock
@@ -136,7 +135,8 @@ void clk_print_clock_tree(clock_sys_t* clock_sys);
  * @return               0 on success;
 
  */
-static inline int clk_gate_enable(clock_sys_t* clock_sys, enum clock_gate gate,
+static inline int clk_gate_enable(const clock_sys_t* clock_sys,
+                                  enum clock_gate gate,
                                   enum clock_gate_mode mode)
 {
     assert(clock_sys);
@@ -151,7 +151,7 @@ static inline int clk_gate_enable(clock_sys_t* clock_sys, enum clock_gate gate,
  * @return           The hz the clock was set to
  *                   (may not exactly match input param)
  */
-static inline freq_t clk_set_freq(clk_t* clk, freq_t hz)
+static inline freq_t clk_set_freq(const clk_t* clk, freq_t hz)
 {
     assert(clk);
     assert(clk->set_freq);
@@ -165,7 +165,7 @@ static inline freq_t clk_set_freq(clk_t* clk, freq_t hz)
  * @return           The hz the clock was set to
  *                   (may not exactly match input param)
  */
-static inline freq_t clk_get_freq(clk_t* clk)
+static inline freq_t clk_get_freq(const clk_t* clk)
 {
     assert(clk);
     assert(clk->get_freq);

--- a/libplatsupport/arch_include/arm/platsupport/mux.h
+++ b/libplatsupport/arch_include/arm/platsupport/mux.h
@@ -25,9 +25,10 @@ enum mux_gpio_dir {
 };
 
 struct mux_sys {
-    int (*feature_enable)(mux_sys_t* mux, enum mux_feature, enum mux_gpio_dir);
-    int (*feature_disable)(mux_sys_t* mux, enum mux_feature);
-    void *(*get_mux_vaddr)(mux_sys_t *mux);
+    int (*feature_enable)(const mux_sys_t* mux, enum mux_feature,
+                          enum mux_gpio_dir);
+    int (*feature_disable)(const mux_sys_t* mux, enum mux_feature);
+    void *(*get_mux_vaddr)(const mux_sys_t *mux);
     void *priv;
 };
 
@@ -42,7 +43,7 @@ static inline int mux_sys_valid(const mux_sys_t* mux_sys)
  * Returns the vaddr of the mux controller so a driver can directly
  * access the MUX controller and bypass the muxc.
  */
-static inline void * mux_sys_get_vaddr(mux_sys_t *mux) {
+static inline void * mux_sys_get_vaddr(const mux_sys_t *mux) {
     return (mux && mux->get_mux_vaddr) ? mux->get_mux_vaddr(mux) : NULL;
 }
 
@@ -57,7 +58,7 @@ static inline void * mux_sys_get_vaddr(mux_sys_t *mux) {
  *                              pointers here.
  * @return             0 on success.
  */
-int mux_sys_init(ps_io_ops_t* io_ops, void *dependencies, mux_sys_t* mux);
+int mux_sys_init(const ps_io_ops_t* io_ops, void *dependencies, mux_sys_t* mux);
 
 /**
  * Enable a SoC feature via the IO MUX
@@ -75,7 +76,8 @@ int mux_sys_init(ps_io_ops_t* io_ops, void *dependencies, mux_sys_t* mux);
  *                          MUX_DIR_NOT_A_GPIO.
  * @return                0 on success
  */
-static inline int mux_feature_enable(mux_sys_t* mux, enum mux_feature mux_feature,
+static inline int mux_feature_enable(const mux_sys_t* mux,
+                                     enum mux_feature mux_feature,
                                      enum mux_gpio_dir mux_gpio_dir)
 {
     if (mux->feature_enable) {

--- a/libplatsupport/arch_include/arm/platsupport/src.h
+++ b/libplatsupport/arch_include/arm/platsupport/src.h
@@ -24,7 +24,7 @@ typedef struct src_dev {
  * @param[out] dev      A device structure to initialise
  * @return              0 on success
  */
-int reset_controller_init(enum src_id, ps_io_ops_t* ops, src_dev_t* dev);
+int reset_controller_init(enum src_id, const ps_io_ops_t* ops, src_dev_t* dev);
 
 /**
  * Reset a subsubsystem.

--- a/libplatsupport/include/platsupport/io.h
+++ b/libplatsupport/include/platsupport/io.h
@@ -67,7 +67,7 @@ typedef struct ps_io_mapper {
 } ps_io_mapper_t;
 
 static inline void *
-ps_io_map(ps_io_mapper_t *io_mapper, uintptr_t paddr, size_t size, int cached, ps_mem_flags_t flags)
+ps_io_map(const ps_io_mapper_t *io_mapper, uintptr_t paddr, size_t size, int cached, ps_mem_flags_t flags)
 {
     assert(io_mapper);
     assert(io_mapper->io_map_fn);
@@ -75,7 +75,7 @@ ps_io_map(ps_io_mapper_t *io_mapper, uintptr_t paddr, size_t size, int cached, p
 }
 
 static inline void
-ps_io_unmap(ps_io_mapper_t *io_mapper, void *vaddr, size_t size)
+ps_io_unmap(const ps_io_mapper_t *io_mapper, void *vaddr, size_t size)
 {
     assert(io_mapper);
     assert(io_mapper->io_unmap_fn);
@@ -113,7 +113,8 @@ typedef struct ps_io_port_ops {
 } ps_io_port_ops_t;
 
 static inline int
-ps_io_port_in(ps_io_port_ops_t *port_ops, uint32_t port, int io_size, uint32_t *result)
+ps_io_port_in(const ps_io_port_ops_t *port_ops, uint32_t port, int io_size,
+              uint32_t *result)
 {
     assert(port_ops);
     assert(port_ops->io_port_in_fn);
@@ -121,7 +122,8 @@ ps_io_port_in(ps_io_port_ops_t *port_ops, uint32_t port, int io_size, uint32_t *
 }
 
 static inline int
-ps_io_port_out(ps_io_port_ops_t *port_ops, uint32_t port, int io_size, uint32_t val)
+ps_io_port_out(const ps_io_port_ops_t *port_ops, uint32_t port, int io_size,
+               uint32_t val)
 {
     assert(port_ops);
     assert(port_ops->io_port_out_fn);
@@ -204,7 +206,8 @@ typedef struct ps_dma_man {
 } ps_dma_man_t;
 
 static inline void *
-ps_dma_alloc(ps_dma_man_t *dma_man, size_t size, int align, int cache, ps_mem_flags_t flags)
+ps_dma_alloc(const ps_dma_man_t *dma_man, size_t size, int align, int cache,
+             ps_mem_flags_t flags)
 {
     assert(dma_man);
     assert(dma_man->dma_alloc_fn);
@@ -212,7 +215,7 @@ ps_dma_alloc(ps_dma_man_t *dma_man, size_t size, int align, int cache, ps_mem_fl
 }
 
 static inline void
-ps_dma_free(ps_dma_man_t *dma_man, void *addr, size_t size)
+ps_dma_free(const ps_dma_man_t *dma_man, void *addr, size_t size)
 {
     assert(dma_man);
     assert(dma_man->dma_free_fn);
@@ -220,7 +223,7 @@ ps_dma_free(ps_dma_man_t *dma_man, void *addr, size_t size)
 }
 
 static inline uintptr_t
-ps_dma_pin(ps_dma_man_t *dma_man, void *addr, size_t size)
+ps_dma_pin(const ps_dma_man_t *dma_man, void *addr, size_t size)
 {
     assert(dma_man);
     assert(dma_man->dma_pin_fn);
@@ -228,7 +231,7 @@ ps_dma_pin(ps_dma_man_t *dma_man, void *addr, size_t size)
 }
 
 static inline void
-ps_dma_unpin(ps_dma_man_t *dma_man, void *addr, size_t size)
+ps_dma_unpin(const ps_dma_man_t *dma_man, void *addr, size_t size)
 {
     assert(dma_man);
     assert(dma_man->dma_unpin_fn);
@@ -236,7 +239,8 @@ ps_dma_unpin(ps_dma_man_t *dma_man, void *addr, size_t size)
 }
 
 static inline void
-ps_dma_cache_op(ps_dma_man_t *dma_man, void *addr, size_t size, dma_cache_op_t op)
+ps_dma_cache_op(const ps_dma_man_t *dma_man, void *addr, size_t size,
+                dma_cache_op_t op)
 {
     assert(dma_man);
     assert(dma_man->dma_cache_op_fn);
@@ -244,19 +248,20 @@ ps_dma_cache_op(ps_dma_man_t *dma_man, void *addr, size_t size, dma_cache_op_t o
 }
 
 static inline void
-ps_dma_cache_clean(ps_dma_man_t *dma_man, void *addr, size_t size)
+ps_dma_cache_clean(const ps_dma_man_t *dma_man, void *addr, size_t size)
 {
     ps_dma_cache_op(dma_man, addr, size, DMA_CACHE_OP_CLEAN);
 }
 
 static inline void
-ps_dma_cache_invalidate(ps_dma_man_t *dma_man, void *addr, size_t size)
+ps_dma_cache_invalidate(const ps_dma_man_t *dma_man, void *addr, size_t size)
 {
     ps_dma_cache_op(dma_man, addr, size, DMA_CACHE_OP_INVALIDATE);
 }
 
 static inline void
-ps_dma_cache_clean_invalidate(ps_dma_man_t *dma_man, void *addr, size_t size)
+ps_dma_cache_clean_invalidate(const ps_dma_man_t *dma_man, void *addr,
+                              size_t size)
 {
     ps_dma_cache_op(dma_man, addr, size, DMA_CACHE_OP_CLEAN_INVALIDATE);
 }
@@ -302,7 +307,8 @@ typedef struct {
     void *cookie;
 } ps_malloc_ops_t;
 
-static inline int ps_malloc(ps_malloc_ops_t *ops, size_t size, void **ptr)
+static inline int ps_malloc(const ps_malloc_ops_t *ops, size_t size,
+                            void **ptr)
 {
     if (ops == NULL) {
         ZF_LOGE("ops cannot be NULL");
@@ -328,7 +334,8 @@ static inline int ps_malloc(ps_malloc_ops_t *ops, size_t size, void **ptr)
     return ops->malloc(ops->cookie, size, ptr);
 }
 
-static inline int ps_calloc(ps_malloc_ops_t *ops, size_t nmemb, size_t size, void **ptr)
+static inline int ps_calloc(const ps_malloc_ops_t *ops, size_t nmemb,
+                            size_t size, void **ptr)
 {
 
     if (ops == NULL) {
@@ -355,7 +362,7 @@ static inline int ps_calloc(ps_malloc_ops_t *ops, size_t nmemb, size_t size, voi
     return ops->calloc(ops->cookie, nmemb, size, ptr);
 }
 
-static inline int ps_free(ps_malloc_ops_t *ops, size_t size, void *ptr)
+static inline int ps_free(const ps_malloc_ops_t *ops, size_t size, void *ptr)
 {
     if (ops == NULL) {
         ZF_LOGE("ops cannot be NULL");
@@ -389,7 +396,7 @@ typedef struct ps_fdt {
     ps_io_fdt_get_fn_t get_fn;
 } ps_io_fdt_t;
 
-static inline char *ps_io_fdt_get(ps_io_fdt_t *io_fdt)
+static inline char *ps_io_fdt_get(const ps_io_fdt_t *io_fdt)
 {
     if (io_fdt == NULL) {
         ZF_LOGE("fdt cannot be NULL");

--- a/libplatsupport/include/platsupport/serial.h
+++ b/libplatsupport/include/platsupport/serial.h
@@ -39,7 +39,7 @@ enum serial_parity {
  * @return   : 0 on success
  */
 int serial_init(enum chardev_id id,
-                ps_io_ops_t* ops,
+                const ps_io_ops_t* ops,
                 ps_chardevice_t* dev);
 
 /*

--- a/libplatsupport/mach_include/exynos/platsupport/mach/serial.h
+++ b/libplatsupport/mach_include/exynos/platsupport/mach/serial.h
@@ -43,8 +43,11 @@ typedef struct {
  * @param[out] dev    A character device structure to initialise
  * @return            0 on success
  */
-int exynos_serial_init(enum chardev_id id, void* vaddr, mux_sys_t* mux_sys,
-                       clk_t* clk_src, ps_chardevice_t* dev);
+int exynos_serial_init(enum chardev_id id,
+                       void* vaddr,
+                       const mux_sys_t* mux_sys,
+                       const clk_t* clk_src,
+                       ps_chardevice_t* dev);
 
 /*
  * Handles only the receive interrupt. Allows RX and TX work to be seperated

--- a/libplatsupport/mach_include/zynq/platsupport/mach/timer.h
+++ b/libplatsupport/mach_include/zynq/platsupport/mach/timer.h
@@ -163,15 +163,15 @@ static inline int ttc_irq(ttc_id_t id)
 }
 
 int ttc_init(ttc_t *ttc, ttc_config_t config);
-int ttc_start(ttc_t *ttc);
-int ttc_stop(ttc_t *ttc);
+int ttc_start(const ttc_t *ttc);
+int ttc_stop(const ttc_t *ttc);
 int ttc_set_timeout(ttc_t *ttc, uint64_t ns, bool periodic);
 /* set the ttc to 0 and start free running, where the timer will
  * continually increment and trigger irqs on each overflow and reload to 0 */
-void ttc_freerun(ttc_t *tcc);
+void ttc_freerun(const ttc_t *tcc);
 /* read the ttc status bit, which will clear any pending irqs. A high return value
  * indicates that and interrupt was pending */
-int ttc_handle_irq(ttc_t *ttc);
-uint64_t ttc_get_time(ttc_t *ttc);
+int ttc_handle_irq(const ttc_t *ttc);
+uint64_t ttc_get_time(const ttc_t *ttc);
 /* convert from a ticks value to ns for a configured ttc */
-uint64_t ttc_ticks_to_ns(ttc_t *ttc, uint32_t ticks);
+uint64_t ttc_ticks_to_ns(const ttc_t *ttc, uint32_t ticks);

--- a/libplatsupport/plat_include/tk1/platsupport/plat/mux.h
+++ b/libplatsupport/plat_include/tk1/platsupport/plat/mux.h
@@ -272,5 +272,5 @@ enum mux_pad {
 };
 
 int tegra_mux_init(volatile void *pinmux_misc, volatile void *pinmux_aux,
-               ps_io_ops_t *io_ops,
+               const ps_io_ops_t *io_ops,
                gpio_sys_t *gpio_sys, mux_sys_t *self);

--- a/libplatsupport/src/arch/arm/clock.c
+++ b/libplatsupport/src/arch/arm/clock.c
@@ -203,7 +203,7 @@ clk_generate_fixed_clk(enum clk_id id, freq_t frequency)
  * their own symbol with an implementation
  */
 WEAK int
-clock_sys_init(ps_io_ops_t* io_ops, clock_sys_t* clk_sys)
+clock_sys_init(ps_io_ops_t* io_ops UNUSED, clock_sys_t* clk_sys UNUSED)
 {
     return 0;
 }

--- a/libplatsupport/src/arch/arm/clock.c
+++ b/libplatsupport/src/arch/arm/clock.c
@@ -17,19 +17,19 @@
 
 /* Fixed clocks */
 static freq_t
-_fixed_clk_get_freq(clk_t* clk)
+_fixed_clk_get_freq(const clk_t* clk)
 {
     return clk->req_freq;
 }
 
 static freq_t
-_fixed_clk_set_freq(clk_t* clk, freq_t hz UNUSED)
+_fixed_clk_set_freq(const clk_t* clk, freq_t hz UNUSED)
 {
     return clk_get_freq(clk);
 }
 
 void
-_fixed_clk_recal(clk_t* clk UNUSED)
+_fixed_clk_recal(const clk_t* clk UNUSED)
 {
     assert(0);
 }
@@ -42,20 +42,20 @@ _fixed_clk_init(clk_t* clk)
 
 /* Default clocks. Simply report the recorded default frequency */
 freq_t
-_default_clk_get_freq(clk_t* clk)
+_default_clk_get_freq(const clk_t* clk)
 {
     assert(clk->id < NCLOCKS);
     return ps_freq_default[clk->id];
 }
 
 freq_t
-_default_clk_set_freq(clk_t* clk, freq_t hz UNUSED)
+_default_clk_set_freq(const clk_t* clk, freq_t hz UNUSED)
 {
     return clk_get_freq(clk);
 }
 
 void
-_default_clk_recal(clk_t* clk UNUSED)
+_default_clk_recal(const clk_t* clk UNUSED)
 {
     assert(0);
 }
@@ -67,13 +67,12 @@ _default_clk_init(clk_t* clk)
 }
 
 static clk_t*
-get_clock_default(clock_sys_t* clock_sys UNUSED, enum clk_id id)
+get_clock_default(const clock_sys_t* clock_sys, enum clk_id id)
 {
     if (id >= NCLOCKS) {
         return NULL;
     } else {
-        clk_t* clk;
-        clk = ps_clocks[id];
+        clk_t* clk = ps_clocks[id];
         /* Destroy original clock links */
         clk->clk_sys = clock_sys;
         clk->init = _default_clk_init;
@@ -85,7 +84,9 @@ get_clock_default(clock_sys_t* clock_sys UNUSED, enum clk_id id)
 }
 
 static int
-gate_enable_default(clock_sys_t* clock_sys UNUSED, enum clock_gate gate UNUSED, enum clock_gate_mode mode UNUSED)
+gate_enable_default(const clock_sys_t* clock_sys UNUSED,
+                    enum clock_gate gate UNUSED,
+                    enum clock_gate_mode mode UNUSED)
 {
     /* Assume the gate is already enabled */
     return 0;
@@ -113,13 +114,12 @@ clock_sys_set_default_freq(enum clk_id id, freq_t hz)
 }
 
 clk_t*
-ps_get_clock(clock_sys_t* sys, enum clk_id id)
+ps_get_clock(const clock_sys_t* sys, enum clk_id id)
 {
     if (id >= NCLOCKS) {
         return NULL;
     } else {
-        clk_t* clk;
-        clk = ps_clocks[id];
+        clk_t* clk = ps_clocks[id];
         assert(clk);
         assert(ps_clocks[id]->init);
         clk->clk_sys = sys;
@@ -128,7 +128,7 @@ ps_get_clock(clock_sys_t* sys, enum clk_id id)
 }
 
 void
-clk_print_tree(clk_t* clk, const char* prefix)
+clk_print_tree(const clk_t* clk, const char* prefix)
 {
     int depth = strlen(prefix);
     char new_prefix[depth + 2];
@@ -203,7 +203,7 @@ clk_generate_fixed_clk(enum clk_id id, freq_t frequency)
  * their own symbol with an implementation
  */
 WEAK int
-clock_sys_init(ps_io_ops_t* io_ops UNUSED, clock_sys_t* clk_sys UNUSED)
+clock_sys_init(const ps_io_ops_t* io_ops UNUSED, clock_sys_t* clk_sys UNUSED)
 {
     return 0;
 }

--- a/libplatsupport/src/arch/arm/clock.h
+++ b/libplatsupport/src/arch/arm/clock.h
@@ -39,8 +39,8 @@ extern freq_t ps_freq_default[];
 extern clk_t* ps_clocks[];
 
 /** Helpers **/
-static inline clock_sys_t*
-clk_get_clock_sys(clk_t* clk)
+static inline const clock_sys_t*
+clk_get_clock_sys(const clk_t* clk)
 {
     assert(clk);
     return clk->clk_sys;
@@ -55,7 +55,7 @@ clk_init(clk_t* clk)
 }
 
 static inline void
-clk_recal(clk_t* clk)
+clk_recal(const clk_t* clk)
 {
     assert(clk);
     assert(clk->recal);
@@ -70,14 +70,14 @@ clk_recal(clk_t* clk)
  * @param[in] clk     The root of the tree
  * @param[in] prefix  A string prefix to print before each line
  */
-void clk_print_tree(clk_t* clk, const char* prefix);
+void clk_print_tree(const clk_t* clk, const char* prefix);
 
 /* Default clocks - Frequency must be defined in freq_default */
-freq_t _default_clk_get_freq(clk_t* clk);
-freq_t _default_clk_set_freq(clk_t* clk, freq_t hz);
-void   _default_clk_recal(clk_t* clk);
+freq_t _default_clk_get_freq(const clk_t* clk);
+freq_t _default_clk_set_freq(const clk_t* clk, freq_t hz);
+void   _default_clk_recal(const clk_t* clk);
 clk_t* _default_clk_init(clk_t* clk);
 
 /* Generic clock acquisition for all platforms */
-clk_t* ps_get_clock(clock_sys_t* sys, enum clk_id id);
+clk_t* ps_get_clock(const clock_sys_t* sys, enum clk_id id);
 

--- a/libplatsupport/src/arch/arm/mux.c
+++ b/libplatsupport/src/arch/arm/mux.c
@@ -18,7 +18,7 @@
  * their own symbol with an implementation
  */
 WEAK int
-mux_sys_init(ps_io_ops_t* io_ops UNUSED, void *dependencies UNUSED,
+mux_sys_init(const ps_io_ops_t* io_ops UNUSED, void *dependencies UNUSED,
              mux_sys_t* mux UNUSED)
 {
     return 0;

--- a/libplatsupport/src/arch/arm/mux.c
+++ b/libplatsupport/src/arch/arm/mux.c
@@ -18,7 +18,8 @@
  * their own symbol with an implementation
  */
 WEAK int
-mux_sys_init(ps_io_ops_t* io_ops, UNUSED void *dependencies, mux_sys_t* mux)
+mux_sys_init(ps_io_ops_t* io_ops UNUSED, void *dependencies UNUSED,
+             mux_sys_t* mux UNUSED)
 {
     return 0;
 }

--- a/libplatsupport/src/mach/exynos/clock.c
+++ b/libplatsupport/src/mach/exynos/clock.c
@@ -17,7 +17,7 @@
  ***********/
 
 freq_t
-_div_get_freq(clk_t* clk)
+_div_get_freq(const clk_t* clk)
 {
     clk_regs_io_t** clk_regs;
     uint32_t div;
@@ -31,7 +31,7 @@ _div_get_freq(clk_t* clk)
 }
 
 freq_t
-_div_set_freq(clk_t* clk, freq_t hz)
+_div_set_freq(const clk_t* clk, freq_t hz)
 {
     clk_regs_io_t** clk_regs;
     uint32_t div;
@@ -59,7 +59,7 @@ _div_set_freq(clk_t* clk, freq_t hz)
 }
 
 void
-_div_recal(clk_t* clk)
+_div_recal(const clk_t* clk)
 {
     assert(0);
 }
@@ -69,7 +69,7 @@ _div_recal(clk_t* clk)
  ***********/
 
 freq_t
-_pll_get_freq(clk_t* clk)
+_pll_get_freq(const clk_t* clk)
 {
     const struct pll_priv* pll_priv;
     int clkid, pll_idx;
@@ -82,7 +82,7 @@ _pll_get_freq(clk_t* clk)
 }
 
 freq_t
-_pll_set_freq(clk_t* clk, freq_t hz)
+_pll_set_freq(const clk_t* clk, freq_t hz)
 {
     volatile struct pll_regs* pll_regs;
     const struct pll_priv* pll_priv;
@@ -132,7 +132,7 @@ _pll_set_freq(clk_t* clk, freq_t hz)
 }
 
 void
-_pll_recal(clk_t* clk)
+_pll_recal(const clk_t* clk)
 {
     assert(0);
 }

--- a/libplatsupport/src/mach/exynos/clock.h
+++ b/libplatsupport/src/mach/exynos/clock.h
@@ -91,40 +91,40 @@ struct pll_priv {
 };
 
 static inline clk_regs_io_t**
-clk_sys_get_clk_regs(clock_sys_t* clock_sys)
+clk_sys_get_clk_regs(const clock_sys_t* clock_sys)
 {
     clk_regs_io_t** clk_regs_ptr = (clk_regs_io_t**)clock_sys->priv;
     return clk_regs_ptr;
 };
 
 static inline clk_regs_io_t**
-clk_get_clk_regs(clk_t* clk)
+clk_get_clk_regs(const clk_t* clk)
 {
     return clk_sys_get_clk_regs(clk->clk_sys);
 };
 
 static inline const struct pll_priv*
-exynos_clk_get_priv_pll(clk_t* clk) {
+exynos_clk_get_priv_pll(const clk_t* clk) {
     return (const struct pll_priv*)clk->priv;
 }
 
 static inline int
-exynos_clk_get_priv_id(clk_t* clk)
+exynos_clk_get_priv_id(const clk_t* clk)
 {
     return (int)clk->priv;
 }
 
 /* Generic exynos devider */
-freq_t _div_get_freq(clk_t* clk);
-freq_t _div_set_freq(clk_t* clk, freq_t hz);
-void   _div_recal(clk_t* clk);
+freq_t _div_get_freq(const clk_t* clk);
+freq_t _div_set_freq(const clk_t* clk, freq_t hz);
+void   _div_recal(const clk_t* clk);
 /* Generic exynos PLL */
-freq_t _pll_get_freq(clk_t* clk);
-freq_t _pll_set_freq(clk_t* clk, freq_t hz);
-void   _pll_recal(clk_t* clk);
+freq_t _pll_get_freq(const clk_t* clk);
+freq_t _pll_set_freq(const clk_t* clk, freq_t hz);
+void   _pll_recal(const clk_t* clk);
 clk_t* _pll_init(clk_t* clk);
 /* PLL get_freq */
-uint32_t exynos_pll_get_freq(clk_t* clk, int clkid, uint32_t pll_idx);
+uint32_t exynos_pll_get_freq(const clk_t* clk, int clkid, uint32_t pll_idx);
 
 /**** helpers ****/
 static inline void

--- a/libplatsupport/src/mach/exynos/clock/exynos_5422_clock.c
+++ b/libplatsupport/src/mach/exynos/clock/exynos_5422_clock.c
@@ -11,7 +11,7 @@
  */
 #include "../clock.h"
 
-uint32_t exynos_pll_get_freq(clk_t* clk, int clkid, uint32_t pll_idx)
+uint32_t exynos_pll_get_freq(const clk_t* clk, int clkid, uint32_t pll_idx)
 {
     uint32_t v, p, m, s;
     clk_regs_io_t** clk_regs;

--- a/libplatsupport/src/mach/exynos/clock/exynos_common_clock.c
+++ b/libplatsupport/src/mach/exynos/clock/exynos_common_clock.c
@@ -11,7 +11,7 @@
  */
 #include "../clock.h"
 
-uint32_t exynos_pll_get_freq(clk_t* clk, int clkid, uint32_t pll_idx)
+uint32_t exynos_pll_get_freq(const clk_t* clk, int clkid, uint32_t pll_idx)
 {
     uint32_t v, p, m, s;
     uint32_t muxstat;

--- a/libplatsupport/src/mach/exynos/mux.c
+++ b/libplatsupport/src/mach/exynos/mux.c
@@ -147,7 +147,7 @@ exynos_mux_configure(struct mux_cfg* cfg, int pin,
 
 static int
 exynos_mux_feature_enable(mux_sys_t* mux, enum mux_feature mux_feature,
-                          UNUSED enum mux_gpio_dir mgd)
+                          enum mux_gpio_dir mgd UNUSED)
 {
     struct mux_feature_data* data = feature_data[mux_feature];
     (void)mux;
@@ -199,7 +199,7 @@ exynos_mux_init(void* gpioleft, void* gpioright, void* gpioc2c,
 }
 
 int
-mux_sys_init(ps_io_ops_t* io_ops, UNUSED void *dependencies, mux_sys_t* mux)
+mux_sys_init(ps_io_ops_t* io_ops, void *dependencies UNUSED, mux_sys_t* mux)
 {
 
     MAP_IF_NULL(io_ops, EXYNOS_GPIOLEFT,  _bank[GPIO_LEFT_BANK]);

--- a/libplatsupport/src/mach/exynos/mux.c
+++ b/libplatsupport/src/mach/exynos/mux.c
@@ -36,13 +36,13 @@
 static volatile struct mux_bank* _bank[GPIO_NBANKS];
 
 static struct mux_bank**
-mux_priv_get_banks(mux_sys_t* mux) {
+mux_priv_get_banks(const mux_sys_t* mux) {
     assert(mux);
     return (struct mux_bank**)mux->priv;
 }
 
 static struct mux_cfg*
-get_mux_cfg(mux_sys_t* mux, int port) {
+get_mux_cfg(const mux_sys_t* mux, int port) {
     struct mux_bank** bank;
     int b, p;
     bank = mux_priv_get_banks(mux);
@@ -146,7 +146,7 @@ exynos_mux_configure(struct mux_cfg* cfg, int pin,
 }
 
 static int
-exynos_mux_feature_enable(mux_sys_t* mux, enum mux_feature mux_feature,
+exynos_mux_feature_enable(const mux_sys_t* mux, enum mux_feature mux_feature,
                           enum mux_gpio_dir mgd UNUSED)
 {
     struct mux_feature_data* data = feature_data[mux_feature];
@@ -199,7 +199,8 @@ exynos_mux_init(void* gpioleft, void* gpioright, void* gpioc2c,
 }
 
 int
-mux_sys_init(ps_io_ops_t* io_ops, void *dependencies UNUSED, mux_sys_t* mux)
+mux_sys_init(const ps_io_ops_t* io_ops, void *dependencies UNUSED,
+             mux_sys_t* mux)
 {
 
     MAP_IF_NULL(io_ops, EXYNOS_GPIOLEFT,  _bank[GPIO_LEFT_BANK]);

--- a/libplatsupport/src/mach/exynos/serial.c
+++ b/libplatsupport/src/mach/exynos/serial.c
@@ -95,7 +95,7 @@
 
 #define REG_PTR(base, offset)  ((volatile uint32_t *)((char*)(base) + (offset)))
 
-static clk_t *clk;
+static const clk_t *clk;
 
 enum mux_feature uart_mux[] = {
                                   [PS_SERIAL0] = MUX_UART0,
@@ -508,8 +508,8 @@ chardevice_init(ps_chardevice_t* dev, void* vaddr, const int* irqs)
 }
 
 int
-exynos_serial_init(enum chardev_id id, void* vaddr, mux_sys_t* mux_sys,
-                   clk_t* clk_src, ps_chardevice_t* dev)
+exynos_serial_init(enum chardev_id id, void* vaddr, const mux_sys_t* mux_sys,
+                   const clk_t* clk_src, ps_chardevice_t* dev)
 {
     int v;
     uart_flush(dev);
@@ -538,7 +538,7 @@ exynos_serial_init(enum chardev_id id, void* vaddr, mux_sys_t* mux_sys,
 }
 
 static clk_t*
-clk_init(enum clk_id clock_id, ps_io_ops_t* ops)
+clk_init(enum clk_id clock_id, const ps_io_ops_t* ops)
 {
     assert(ops != NULL);
     if (clock_sys_valid(&ops->clock_sys)) {
@@ -548,7 +548,7 @@ clk_init(enum clk_id clock_id, ps_io_ops_t* ops)
 }
 
 int
-serial_init(enum chardev_id id, ps_io_ops_t* ops,
+serial_init(enum chardev_id id, const ps_io_ops_t* ops,
             ps_chardevice_t* dev)
 {
     void* vaddr;

--- a/libplatsupport/src/mach/exynos/spi.c
+++ b/libplatsupport/src/mach/exynos/spi.c
@@ -128,7 +128,7 @@ struct spi_bus {
     int mode: 1;              //0 -- Master, 1 -- Slave
     int high_speed: 1;        //High speed operation in slave mode.
     int cs_auto: 1;           //Auto chip selection.
-    clk_t *clk;               //Clock for changing the bus speed.
+    const clk_t *clk;         //Clock for changing the bus speed.
 
     /* Transfer management */
     const char *txbuf;

--- a/libplatsupport/src/mach/zynq/mux.c
+++ b/libplatsupport/src/mach/zynq/mux.c
@@ -30,7 +30,7 @@ static inline void set_mux_priv(mux_sys_t* mux, struct zynq_mux* zynq_mux)
 }
 
 static int
-zynq_mux_feature_enable(mux_sys_t* mux UNUSED,
+zynq_mux_feature_enable(const mux_sys_t* mux UNUSED,
                         enum mux_feature mux_feature UNUSED,
                         enum mux_gpio_dir mgd UNUSED)
 {
@@ -52,7 +52,8 @@ zynq_mux_init(mux_sys_t* mux)
 }
 
 int
-mux_sys_init(ps_io_ops_t* io_ops, void *dependencies UNUSED, mux_sys_t* mux)
+mux_sys_init(const ps_io_ops_t* io_ops, void *dependencies UNUSED,
+             mux_sys_t* mux)
 {
     return zynq_mux_init_common(mux);
 }

--- a/libplatsupport/src/mach/zynq/mux.c
+++ b/libplatsupport/src/mach/zynq/mux.c
@@ -30,8 +30,9 @@ static inline void set_mux_priv(mux_sys_t* mux, struct zynq_mux* zynq_mux)
 }
 
 static int
-zynq_mux_feature_enable(mux_sys_t* mux, enum mux_feature mux_feature,
-                        UNUSED enum mux_gpio_dir mgd)
+zynq_mux_feature_enable(mux_sys_t* mux UNUSED,
+                        enum mux_feature mux_feature UNUSED,
+                        enum mux_gpio_dir mgd UNUSED)
 {
     return 0;
 }
@@ -51,7 +52,7 @@ zynq_mux_init(mux_sys_t* mux)
 }
 
 int
-mux_sys_init(ps_io_ops_t* io_ops, UNUSED void *dependencies, mux_sys_t* mux)
+mux_sys_init(ps_io_ops_t* io_ops, void *dependencies UNUSED, mux_sys_t* mux)
 {
     return zynq_mux_init_common(mux);
 }

--- a/libplatsupport/src/mach/zynq/serial.c
+++ b/libplatsupport/src/mach/zynq/serial.c
@@ -208,8 +208,10 @@ int uart_getchar(ps_chardevice_t *d)
 
 int uart_putchar(ps_chardevice_t* d, int c)
 {
-    int ret = -1;
     zynq_uart_regs_t* regs = zynq_uart_get_priv(d);
+
+    /* default to error, indicates there is not enough space in the FIFO */
+    int ret = -1;
 
     uint32_t imr = regs->imr;
     regs->idr = imr;
@@ -219,17 +221,17 @@ int uart_putchar(ps_chardevice_t* d, int c)
          * this bit is set if the fifo level is >= the trigger level
          */
         if (!(regs->sr & UART_SR_TTRIG)) {
-
-            regs->fifo = '\r';
-            regs->fifo = '\n';
-
-            ret = '\n';
+            regs->fifo = '\r'; // send CR before LF (\n)
+            regs->fifo = c;
+            ret = c; /* sending was successful */
         }
+
     } else if (!(regs->sr & UART_SR_TFUL)) {
         regs->fifo = c;
-        ret = c;
+        ret = c; /* sending was successful */
     }
 
+    /* block until FIFO is empty */
     while ((regs->sr & (UART_SR_TEMPTY | UART_SR_TACTIVE)) != UART_SR_TEMPTY);
 
     regs->ier = imr;

--- a/libplatsupport/src/mach/zynq/timer.c
+++ b/libplatsupport/src/mach/zynq/timer.c
@@ -134,13 +134,13 @@ struct ttc_tmr_regs {
 };
 typedef volatile struct ttc_tmr_regs ttc_tmr_regs_t;
 
-static freq_t _ttc_clk_get_freq(clk_t* clk);
-static freq_t _ttc_clk_set_freq(clk_t* clk, freq_t hz);
-static void _ttc_clk_recal(clk_t* clk);
+static freq_t _ttc_clk_get_freq(const clk_t* clk);
+static freq_t _ttc_clk_set_freq(const clk_t* clk, freq_t hz);
+static void _ttc_clk_recal(const clk_t* clk);
 static clk_t* _ttc_clk_init(clk_t* clk);
 
 static inline ttc_tmr_regs_t*
-ttc_get_regs(ttc_t *ttc)
+ttc_get_regs(const ttc_t *ttc)
 {
     return ttc->regs;
 }
@@ -148,14 +148,14 @@ ttc_get_regs(ttc_t *ttc)
 /****************** Clocks ******************/
 
 static ttc_t*
-ttc_clk_get_priv(clk_t* clk)
+ttc_clk_get_priv(const clk_t* clk)
 {
     return (ttc_t*)clk->priv;
 }
 
 /* FPGA PL Clocks */
 static freq_t
-_ttc_clk_get_freq(clk_t* clk)
+_ttc_clk_get_freq(const clk_t* clk)
 {
     ttc_t *ttc = ttc_clk_get_priv(clk);
     ttc_tmr_regs_t* regs = ttc_get_regs(ttc);
@@ -179,7 +179,7 @@ _ttc_clk_get_freq(clk_t* clk)
 }
 
 static freq_t
-_ttc_clk_set_freq(clk_t* clk, freq_t hz)
+_ttc_clk_set_freq(const clk_t* clk, freq_t hz)
 {
     ttc_t *ttc = ttc_clk_get_priv(clk);
     ttc_tmr_regs_t* regs = ttc_get_regs(ttc);
@@ -209,7 +209,7 @@ _ttc_clk_set_freq(clk_t* clk, freq_t hz)
 }
 
 static void
-_ttc_clk_recal(clk_t* clk UNUSED)
+_ttc_clk_recal(const clk_t* clk UNUSED)
 {
     assert(0);
 }
@@ -221,7 +221,7 @@ _ttc_clk_init(clk_t* clk)
 }
 
 static inline freq_t
-_ttc_get_freq(ttc_t *ttc)
+_ttc_get_freq(const ttc_t *ttc)
 {
     return ttc->freq;
 }
@@ -281,14 +281,14 @@ _ttc_set_freq_for_ns(ttc_t *ttc, uint64_t ns, uint64_t *interval)
     return 0;
 }
 
-int ttc_start(ttc_t *ttc)
+int ttc_start(const ttc_t *ttc)
 {
     ttc_tmr_regs_t* regs = ttc_get_regs(ttc);
     *regs->cnt_ctrl &= ~CNTCTRL_STOP;
     return 0;
 }
 
-int ttc_stop(ttc_t *ttc)
+int ttc_stop(const ttc_t *ttc)
 {
     ttc_tmr_regs_t* regs = ttc_get_regs(ttc);
     *regs->cnt_ctrl |= CNTCTRL_STOP;
@@ -296,7 +296,7 @@ int ttc_stop(ttc_t *ttc)
     return 0;
 }
 
-void ttc_freerun(ttc_t *ttc)
+void ttc_freerun(const ttc_t *ttc)
 {
     ttc_tmr_regs_t* regs = ttc_get_regs(ttc);
     *regs->cnt_ctrl = CNTCTRL_RST;
@@ -324,7 +324,7 @@ _ttc_periodic(ttc_tmr_regs_t *regs, uint64_t interval)
     return 0;
 }
 
-int ttc_handle_irq(ttc_t *ttc)
+int ttc_handle_irq(const ttc_t *ttc)
 {
     ttc_tmr_regs_t* regs = ttc_get_regs(ttc);
 
@@ -345,7 +345,7 @@ int ttc_handle_irq(ttc_t *ttc)
     return res;
 }
 
-uint64_t ttc_ticks_to_ns(ttc_t *ttc, uint32_t ticks) {
+uint64_t ttc_ticks_to_ns(const ttc_t *ttc, uint32_t ticks) {
     if (!ttc) {
         return 0;
     }
@@ -353,7 +353,7 @@ uint64_t ttc_ticks_to_ns(ttc_t *ttc, uint32_t ticks) {
     return freq_cycles_and_hz_to_ns(ticks, fin);
 }
 
-uint64_t ttc_get_time(ttc_t *ttc)
+uint64_t ttc_get_time(const ttc_t *ttc)
 {
     ttc_tmr_regs_t* regs = ttc_get_regs(ttc);
     uint32_t cnt = *regs->cnt_val;

--- a/libplatsupport/src/plat/apq8064/clock.c
+++ b/libplatsupport/src/plat/apq8064/clock.c
@@ -108,7 +108,7 @@ static struct clock wcnxo_clk  = { CLK_OPS_DEFAULT(WCNXO)  };
 static struct clock slpxo_clk  = { CLK_OPS_DEFAULT(SLPXO)  };
 
 static int
-apq8064_gate_enable(clock_sys_t* sys, enum clock_gate gate, enum clock_gate_mode mode)
+apq8064_gate_enable(const clock_sys_t* sys, enum clock_gate gate, enum clock_gate_mode mode)
 {
     (void)sys;
     (void)gate;
@@ -117,9 +117,9 @@ apq8064_gate_enable(clock_sys_t* sys, enum clock_gate gate, enum clock_gate_mode
 }
 
 void
-clk_print_clock_tree(clock_sys_t* sys)
+clk_print_clock_tree(const clock_sys_t* sys)
 {
-    clk_t *clk = clk_get_clock(sys, CLK_MASTER);
+    const clk_t *clk = clk_get_clock(sys, CLK_MASTER);
     clk_print_tree(clk, "");
 }
 
@@ -131,7 +131,7 @@ static int apq8064_clock_sys_init_common(clock_sys_t* clk_sys)
 }
 
 int
-clock_sys_init(ps_io_ops_t* io_ops, clock_sys_t* clk_sys)
+clock_sys_init(const ps_io_ops_t* io_ops, clock_sys_t* clk_sys)
 {
     struct clock_sys_regs* d = &clk_sys_regs;
     MAP_IF_NULL(io_ops, APQ8064_CLK_CTL0, d->block0);

--- a/libplatsupport/src/plat/apq8064/mux.c
+++ b/libplatsupport/src/plat/apq8064/mux.c
@@ -34,17 +34,17 @@ static inline void set_mux_priv(mux_sys_t* mux, struct apq8064_mux* apq8064_mux)
 }
 
 static int
-apq8064_mux_feature_enable(mux_sys_t* mux, enum mux_feature mux_feature, UNUSED enum mux_gpio_dir mgd)
+apq8064_mux_feature_enable(mux_sys_t* mux, enum mux_feature mux_feature,
+                           enum mux_gpio_dir mgd UNUSED)
 {
-    struct apq8064_mux* m;
     if (mux == NULL || mux->priv == NULL) {
         return -1;
     }
-    m = get_mux_priv(mux);
+
+    struct apq8064_mux* m UNUSED = get_mux_priv(mux);
 
     switch (mux_feature) {
     default:
-        (void)m;
         return -1;
     }
 }
@@ -58,16 +58,15 @@ apq8064_mux_init_common(mux_sys_t* mux)
 }
 
 int
-apq8064_mux_init(void* bank1,
+apq8064_mux_init(UNUSED void* bank1,
                  mux_sys_t* mux)
 {
-    (void)bank1;
     return apq8064_mux_init_common(mux);
 }
 
 int
-mux_sys_init(ps_io_ops_t* io_ops, UNUSED void *dependencies, mux_sys_t* mux)
+mux_sys_init(UNUSED ps_io_ops_t* io_ops, void *dependencies UNUSED,
+             mux_sys_t* mux)
 {
-    (void)io_ops;
     return apq8064_mux_init_common(mux);
 }

--- a/libplatsupport/src/plat/apq8064/mux.c
+++ b/libplatsupport/src/plat/apq8064/mux.c
@@ -22,7 +22,7 @@ static struct apq8064_mux {
     volatile struct apq8064_mux_regs*    mux;
 } _mux;
 
-static inline struct apq8064_mux* get_mux_priv(mux_sys_t* mux) {
+static inline struct apq8064_mux* get_mux_priv(const mux_sys_t* mux) {
     return (struct apq8064_mux*)mux->priv;
 }
 
@@ -34,7 +34,7 @@ static inline void set_mux_priv(mux_sys_t* mux, struct apq8064_mux* apq8064_mux)
 }
 
 static int
-apq8064_mux_feature_enable(mux_sys_t* mux, enum mux_feature mux_feature,
+apq8064_mux_feature_enable(const mux_sys_t* mux, enum mux_feature mux_feature,
                            enum mux_gpio_dir mgd UNUSED)
 {
     if (mux == NULL || mux->priv == NULL) {
@@ -65,7 +65,7 @@ apq8064_mux_init(UNUSED void* bank1,
 }
 
 int
-mux_sys_init(UNUSED ps_io_ops_t* io_ops, void *dependencies UNUSED,
+mux_sys_init(UNUSED const ps_io_ops_t* io_ops, void *dependencies UNUSED,
              mux_sys_t* mux)
 {
     return apq8064_mux_init_common(mux);

--- a/libplatsupport/src/plat/bcm2837/clock.c
+++ b/libplatsupport/src/plat/bcm2837/clock.c
@@ -21,7 +21,7 @@ static struct clock master_clk = { CLK_OPS_DEFAULT(MASTER) };
 static struct clock sp804_clk = { CLK_OPS_DEFAULT(SP804) };
 
 int
-clock_sys_init(ps_io_ops_t* o, clock_sys_t* clock_sys)
+clock_sys_init(const ps_io_ops_t* o, clock_sys_t* clock_sys)
 {
     clock_sys->priv = (void*)0xdeadbeef;
     clock_sys->get_clock = &ps_get_clock;
@@ -30,9 +30,9 @@ clock_sys_init(ps_io_ops_t* o, clock_sys_t* clock_sys)
 }
 
 void
-clk_print_clock_tree(clock_sys_t* sys)
+clk_print_clock_tree(const clock_sys_t* sys)
 {
-    clk_t *clk = clk_get_clock(sys, CLK_MASTER);
+    const clk_t *clk = clk_get_clock(sys, CLK_MASTER);
     clk_print_tree(clk, "");
 }
 

--- a/libplatsupport/src/plat/bcm2837/serial.c
+++ b/libplatsupport/src/plat/bcm2837/serial.c
@@ -51,6 +51,8 @@ uart_handle_irq(ps_chardevice_t* d UNUSED)
 
 int uart_putchar(ps_chardevice_t* d, int c)
 {
+    // ToDo: check SERIAL_AUTO_CR and print CR (\r) first on LF (\n)
+
     while ( !(*REG_PTR(d->vaddr, MU_LSR) & MU_LSR_TXIDLE) );
     *REG_PTR(d->vaddr, MU_IO) = (c & 0xff);
 

--- a/libplatsupport/src/plat/exynos4/clock.c
+++ b/libplatsupport/src/plat/exynos4/clock.c
@@ -209,13 +209,13 @@ static struct clock divcopy_clk   = { CLK_OPS(DIVCOPY    , div, CLKID_DIVCOPY)  
  **** MUXes ****
  ***************/
 static freq_t
-_mux_get_freq(clk_t* clk)
+_mux_get_freq(const clk_t* clk)
 {
     return clk_get_freq(clk->parent);
 }
 
 static freq_t
-_mux_set_freq(clk_t* clk, freq_t hz)
+_mux_set_freq(const clk_t* clk, freq_t hz)
 {
     /* TODO: we can choose a different source... */
     clk_set_freq(clk->parent, hz);
@@ -223,7 +223,7 @@ _mux_set_freq(clk_t* clk, freq_t hz)
 }
 
 static void
-_mux_recal(clk_t* clk)
+_mux_recal(const clk_t* clk)
 {
     assert(0);
 }
@@ -277,20 +277,20 @@ static struct clock muxhpm_clk = { CLK_OPS(MUXHPM, mux, NULL) };
  ****  SPI  ****
  ***************/
 static freq_t
-_spi_get_freq(clk_t* clk)
+_spi_get_freq(const clk_t* clk)
 {
     return 0;
 }
 
 static freq_t
-_spi_set_freq(clk_t* clk, freq_t hz)
+_spi_set_freq(const clk_t* clk, freq_t hz)
 {
     (void)hz;
     return clk_get_freq(clk);
 }
 
 static void
-_spi_recal(clk_t* clk)
+_spi_recal(const clk_t* clk)
 {
     assert(0);
 }
@@ -310,7 +310,8 @@ static struct clock spi1_isp_clk = { CLK_OPS(SPI1_ISP, spi, NULL) };
 /*******************************************/
 
 static int
-exynos4_gate_enable(clock_sys_t* sys, enum clock_gate gate, enum clock_gate_mode mode)
+exynos4_gate_enable(const clock_sys_t* sys, enum clock_gate gate,
+                    enum clock_gate_mode mode)
 {
     (void)sys;
     (void)gate;
@@ -328,7 +329,7 @@ clock_sys_common_init(clock_sys_t* clock_sys)
 }
 
 int
-clock_sys_init(ps_io_ops_t* o, clock_sys_t* clock_sys)
+clock_sys_init(const ps_io_ops_t* o, clock_sys_t* clock_sys)
 {
     MAP_IF_NULL(o, CMU_LEFTBUS , _clk_regs[CLKREGS_LEFT]);
     MAP_IF_NULL(o, CMU_RIGHTBUS, _clk_regs[CLKREGS_RIGHT]);
@@ -342,7 +343,7 @@ clock_sys_init(ps_io_ops_t* o, clock_sys_t* clock_sys)
 }
 
 void
-clk_print_clock_tree(clock_sys_t* sys UNUSED)
+clk_print_clock_tree(const clock_sys_t* sys UNUSED)
 {
     clk_t* clk = ps_clocks[CLK_MASTER];
     clk_print_tree(clk, "");

--- a/libplatsupport/src/plat/exynos4/src.c
+++ b/libplatsupport/src/plat/exynos4/src.c
@@ -100,7 +100,7 @@ reset_controller_assert_reset(src_dev_t* dev, enum src_rst_id id)
 }
 
 int
-reset_controller_init(enum src_id id, ps_io_ops_t* ops, src_dev_t* dev)
+reset_controller_init(enum src_id id, const ps_io_ops_t* ops, src_dev_t* dev)
 {
     struct src_priv* src_priv = &_src_priv;
     int i;

--- a/libplatsupport/src/plat/exynos5/clock.c
+++ b/libplatsupport/src/plat/exynos5/clock.c
@@ -355,9 +355,8 @@ clock_sys_init(ps_io_ops_t* o, clock_sys_t* clock_sys)
 }
 
 void
-clk_print_clock_tree(clock_sys_t* sys)
+clk_print_clock_tree(clock_sys_t* sys UNUSED)
 {
-    (void)sys;
     clk_t* clk = ps_clocks[CLK_MASTER];
     clk_print_tree(clk, "");
 }

--- a/libplatsupport/src/plat/exynos5/clock.c
+++ b/libplatsupport/src/plat/exynos5/clock.c
@@ -132,7 +132,7 @@ static struct clock sclkbpll_clk  = { CLK_OPS(SCLKBPLL, pll, &sclkbpll_priv) };
 /* The SPI div register is a special case as we have 2 dividers, one of which
  * is 2 nibbles wide */
 static freq_t
-_spi_get_freq(clk_t* clk)
+_spi_get_freq(const clk_t* clk)
 {
     freq_t fin;
     int clkid;
@@ -164,7 +164,7 @@ _spi_get_freq(clk_t* clk)
 }
 
 static freq_t
-_spi_set_freq(clk_t* clk, freq_t hz)
+_spi_set_freq(const clk_t* clk, freq_t hz)
 {
     freq_t fin;
     int clkid;
@@ -198,7 +198,7 @@ _spi_set_freq(clk_t* clk, freq_t hz)
 }
 
 static void
-_spi_recal(clk_t* clk)
+_spi_recal(const clk_t* clk)
 {
     assert(!"Not implemented");
 }
@@ -228,7 +228,7 @@ static struct clock spi0_isp_clk = { CLK_OPS(SPI0_ISP, spi, CLKID_SPI0_ISP) };
 static struct clock spi1_isp_clk = { CLK_OPS(SPI1_ISP, spi, CLKID_SPI1_ISP) };
 
 static freq_t
-_peric_clk_get_freq(clk_t* clk)
+_peric_clk_get_freq(const clk_t* clk)
 {
     freq_t fin;
     int clkid;
@@ -242,7 +242,7 @@ _peric_clk_get_freq(clk_t* clk)
 }
 
 static freq_t
-_peric_clk_set_freq(clk_t* clk, freq_t hz)
+_peric_clk_set_freq(const clk_t* clk, freq_t hz)
 {
     freq_t fin;
     int clkid;
@@ -257,7 +257,7 @@ _peric_clk_set_freq(clk_t* clk, freq_t hz)
 }
 
 static void
-_peric_clk_recal(clk_t* clk)
+_peric_clk_recal(const clk_t* clk)
 {
     assert(!"Not implemented");
 }
@@ -287,7 +287,8 @@ static struct clock uart3_clk = { CLK_OPS(UART3, peric_clk, CLKID_UART3) };
 static struct clock pwm_clk   = { CLK_OPS(PWM  , peric_clk, CLKID_PWM  ) };
 
 static int
-exynos5_gate_enable(clock_sys_t* clock_sys, enum clock_gate gate, enum clock_gate_mode mode)
+exynos5_gate_enable(const clock_sys_t* clock_sys, enum clock_gate gate,
+                    enum clock_gate_mode mode)
 {
     return -1;
 }
@@ -340,7 +341,7 @@ exynos5_clock_sys_init(void* cpu, void* core, void* acp, void* isp, void* top,
 }
 
 int
-clock_sys_init(ps_io_ops_t* o, clock_sys_t* clock_sys)
+clock_sys_init(const ps_io_ops_t* o, clock_sys_t* clock_sys)
 {
     MAP_IF_NULL(o, EXYNOS5_CMU_CPU,   _clk_regs[CLKREGS_CPU]);
     MAP_IF_NULL(o, EXYNOS5_CMU_CORE,  _clk_regs[CLKREGS_CORE]);
@@ -355,7 +356,7 @@ clock_sys_init(ps_io_ops_t* o, clock_sys_t* clock_sys)
 }
 
 void
-clk_print_clock_tree(clock_sys_t* sys UNUSED)
+clk_print_clock_tree(const clock_sys_t* sys UNUSED)
 {
     clk_t* clk = ps_clocks[CLK_MASTER];
     clk_print_tree(clk, "");

--- a/libplatsupport/src/plat/hikey/serial.c
+++ b/libplatsupport/src/plat/hikey/serial.c
@@ -35,14 +35,22 @@ int uart_getchar(ps_chardevice_t *d)
     return ch;
 }
 
+static void internal_uart_putchar(void* vaddr, int c)
+{
+    while ((*REG_PTR(vaddr, UARTFR) & PL011_UARTFR_TXFF) != 0) {
+        continue;
+    }
+    *REG_PTR(vaddr, UARTDR) = c;
+}
+
 int uart_putchar(ps_chardevice_t* d, int c)
 {
-    while ((*REG_PTR(d->vaddr, UARTFR) & PL011_UARTFR_TXFF) != 0);
-
-    *REG_PTR(d->vaddr, UARTDR) = c;
+    void* vaddr = d->vaddr;
+    /* SERIAL_AUTO_CR: Send '\r' (CR) before every '\n' (LF). */
     if (c == '\n' && (d->flags & SERIAL_AUTO_CR)) {
-        uart_putchar(d, '\r');
+        internal_uart_putchar(vaddr, '\r');
     }
+    internal_uart_putchar(vaddr, c);
 
     return c;
 }

--- a/libplatsupport/src/plat/imx31/clock.c
+++ b/libplatsupport/src/plat/imx31/clock.c
@@ -20,14 +20,15 @@ static volatile struct clock_regs {
 } clk_regs;
 
 static int
-imx31_gate_enable(clock_sys_t* clock_sys UNUSED, enum clock_gate gate UNUSED,
+imx31_gate_enable(const clock_sys_t* clock_sys UNUSED,
+                  enum clock_gate gate UNUSED,
                   enum clock_gate_mode mode UNUSED)
 {
     return -1;
 }
 
 int
-clock_sys_init(ps_io_ops_t* o, clock_sys_t* clock_sys)
+clock_sys_init(const ps_io_ops_t* o, clock_sys_t* clock_sys)
 {
     clock_sys->priv = (void*)&clk_regs;
     clock_sys->get_clock = &ps_get_clock;
@@ -36,9 +37,9 @@ clock_sys_init(ps_io_ops_t* o, clock_sys_t* clock_sys)
 }
 
 void
-clk_print_clock_tree(clock_sys_t* sys)
+clk_print_clock_tree(const clock_sys_t* sys)
 {
-    clk_t *clk = clk_get_clock(sys, CLK_MASTER);
+    const clk_t *clk = clk_get_clock(sys, CLK_MASTER);
     clk_print_tree(clk, "");
 }
 

--- a/libplatsupport/src/plat/imx31/clock.c
+++ b/libplatsupport/src/plat/imx31/clock.c
@@ -20,7 +20,8 @@ static volatile struct clock_regs {
 } clk_regs;
 
 static int
-imx31_gate_enable(clock_sys_t* clock_sys, enum clock_gate gate, enum clock_gate_mode mode)
+imx31_gate_enable(clock_sys_t* clock_sys UNUSED, enum clock_gate gate UNUSED,
+                  enum clock_gate_mode mode UNUSED)
 {
     return -1;
 }

--- a/libplatsupport/src/plat/imx31/mux.c
+++ b/libplatsupport/src/plat/imx31/mux.c
@@ -22,7 +22,7 @@ static struct imx31_mux {
     volatile struct imx31_mux_regs*    mux;
 } _mux;
 
-static inline struct imx31_mux* get_mux_priv(mux_sys_t* mux) {
+static inline struct imx31_mux* get_mux_priv(const mux_sys_t* mux) {
     return (struct imx31_mux*)mux->priv;
 }
 
@@ -34,7 +34,7 @@ static inline void set_mux_priv(mux_sys_t* mux, struct imx31_mux* imx31_mux)
 }
 
 static int
-imx31_mux_feature_enable(mux_sys_t* mux, enum mux_feature mux_feature,
+imx31_mux_feature_enable(const mux_sys_t* mux, enum mux_feature mux_feature,
                          enum mux_gpio_dir mgd UNUSED)
 {
     if (mux == NULL || mux->priv == NULL) {
@@ -65,7 +65,7 @@ imx31_mux_init(void* bank1 UNUSED,
 }
 
 int
-mux_sys_init(ps_io_ops_t* io_ops UNUSED, void *dependencies UNUSED,
+mux_sys_init(const ps_io_ops_t* io_ops UNUSED, void *dependencies UNUSED,
              mux_sys_t* mux)
 {
     return imx31_mux_init_common(mux);

--- a/libplatsupport/src/plat/imx31/mux.c
+++ b/libplatsupport/src/plat/imx31/mux.c
@@ -34,17 +34,17 @@ static inline void set_mux_priv(mux_sys_t* mux, struct imx31_mux* imx31_mux)
 }
 
 static int
-imx31_mux_feature_enable(mux_sys_t* mux, enum mux_feature mux_feature, UNUSED enum mux_gpio_dir mgd)
+imx31_mux_feature_enable(mux_sys_t* mux, enum mux_feature mux_feature,
+                         enum mux_gpio_dir mgd UNUSED)
 {
-    struct imx31_mux* m;
     if (mux == NULL || mux->priv == NULL) {
         return -1;
     }
-    m = get_mux_priv(mux);
+
+    struct imx31_mux* m UNUSED = get_mux_priv(mux);
 
     switch (mux_feature) {
     default:
-        (void)m;
         return -1;
     }
 }
@@ -58,16 +58,15 @@ imx31_mux_init_common(mux_sys_t* mux)
 }
 
 int
-imx31_mux_init(void* bank1,
+imx31_mux_init(void* bank1 UNUSED,
                mux_sys_t* mux)
 {
-    (void)bank1;
     return imx31_mux_init_common(mux);
 }
 
 int
-mux_sys_init(ps_io_ops_t* io_ops, UNUSED void *dependencies, mux_sys_t* mux)
+mux_sys_init(ps_io_ops_t* io_ops UNUSED, void *dependencies UNUSED,
+             mux_sys_t* mux)
 {
-    (void)io_ops;
     return imx31_mux_init_common(mux);
 }

--- a/libplatsupport/src/plat/imx6/clock.c
+++ b/libplatsupport/src/plat/imx6/clock.c
@@ -192,7 +192,7 @@ static struct clock master_clk = { CLK_OPS_DEFAULT(MASTER) };
 
 /* ARM_CLK */
 static freq_t
-_arm_get_freq(clk_t* clk)
+_arm_get_freq(const clk_t* clk)
 {
     uint32_t div;
     uint32_t fout, fin;
@@ -204,7 +204,7 @@ _arm_get_freq(clk_t* clk)
 }
 
 static freq_t
-_arm_set_freq(clk_t* clk, freq_t hz)
+_arm_set_freq(const clk_t* clk, freq_t hz)
 {
     uint32_t div;
     uint32_t fin;
@@ -227,7 +227,7 @@ _arm_set_freq(clk_t* clk, freq_t hz)
 }
 
 static void
-_arm_recal(clk_t* clk UNUSED)
+_arm_recal(const clk_t* clk UNUSED)
 {
     assert(0);
 }
@@ -249,7 +249,7 @@ static struct clock arm_clk = { CLK_OPS(ARM, arm, NULL) };
 /* ENET_CLK */
 
 static freq_t
-_enet_get_freq(clk_t* clk)
+_enet_get_freq(const clk_t* clk)
 {
     uint32_t div;
     uint32_t fin;
@@ -272,7 +272,7 @@ _enet_get_freq(clk_t* clk)
 }
 
 static freq_t
-_enet_set_freq(clk_t* clk, freq_t hz)
+_enet_set_freq(const clk_t* clk, freq_t hz)
 {
     uint32_t div, fin;
     uint32_t v;
@@ -307,7 +307,7 @@ _enet_set_freq(clk_t* clk, freq_t hz)
 }
 
 static void
-_enet_recal(clk_t* clk UNUSED)
+_enet_recal(const clk_t* clk UNUSED)
 {
     assert(0);
 }
@@ -327,7 +327,7 @@ static struct clock enet_clk = { CLK_OPS(ENET, enet, NULL) };
 
 /* PLL2_CLK */
 static freq_t
-_pll2_get_freq(clk_t* clk)
+_pll2_get_freq(const clk_t* clk)
 {
     uint32_t p, s;
     struct pll2_regs *regs;
@@ -347,7 +347,7 @@ _pll2_get_freq(clk_t* clk)
 }
 
 static freq_t
-_pll2_set_freq(clk_t* clk, freq_t hz)
+_pll2_set_freq(const clk_t* clk, freq_t hz)
 {
     uint32_t s;
     if (clk_regs.alg == NULL) {
@@ -360,7 +360,7 @@ _pll2_set_freq(clk_t* clk, freq_t hz)
 }
 
 static void
-_pll2_recal(clk_t* clk UNUSED)
+_pll2_recal(const clk_t* clk UNUSED)
 {
     assert(0);
 }
@@ -380,13 +380,13 @@ static struct clock pll2_clk = { CLK_OPS(PLL2, pll2, NULL) };
 
 /* MMDC_CH0_CLK */
 static freq_t
-_mmdc_ch0_get_freq(clk_t* clk)
+_mmdc_ch0_get_freq(const clk_t* clk)
 {
     return clk_get_freq(clk->parent);
 }
 
 static freq_t
-_mmdc_ch0_set_freq(clk_t* clk, freq_t hz)
+_mmdc_ch0_set_freq(const clk_t* clk, freq_t hz)
 {
     /* TODO there is a mux here */
     assert(hz == 528 * MHZ);
@@ -394,7 +394,7 @@ _mmdc_ch0_set_freq(clk_t* clk, freq_t hz)
 }
 
 static void
-_mmdc_ch0_recal(clk_t* clk UNUSED)
+_mmdc_ch0_recal(const clk_t* clk UNUSED)
 {
     assert(0);
 }
@@ -414,19 +414,19 @@ static struct clock mmdc_ch0_clk = { CLK_OPS(MMDC_CH0, mmdc_ch0, NULL) };
 
 /* AHB_CLK_ROOT */
 static freq_t
-_ahb_get_freq(clk_t* clk)
+_ahb_get_freq(const clk_t* clk)
 {
     return clk_get_freq(clk->parent) / 4;
 }
 
 static freq_t
-_ahb_set_freq(clk_t* clk, freq_t hz)
+_ahb_set_freq(const clk_t* clk, freq_t hz)
 {
     return clk_set_freq(clk->parent, hz * 4);
 }
 
 static void
-_ahb_recal(clk_t* clk UNUSED)
+_ahb_recal(const clk_t* clk UNUSED)
 {
     assert(0);
 }
@@ -446,19 +446,19 @@ static struct clock ahb_clk = { CLK_OPS(AHB, ahb, NULL) };
 
 /* IPG_CLK_ROOT */
 static freq_t
-_ipg_get_freq(clk_t* clk)
+_ipg_get_freq(const clk_t* clk)
 {
     return clk_get_freq(clk->parent) / 2;
 };
 
 static freq_t
-_ipg_set_freq(clk_t* clk, freq_t hz)
+_ipg_set_freq(const clk_t* clk, freq_t hz)
 {
     return clk_set_freq(clk->parent, hz * 2);
 };
 
 static void
-_ipg_recal(clk_t* clk UNUSED)
+_ipg_recal(const clk_t* clk UNUSED)
 {
     assert(0);
 }
@@ -478,7 +478,7 @@ static struct clock ipg_clk = { CLK_OPS(IPG, ipg, NULL) };
 
 /* USB_CLK */
 static freq_t
-_usb_get_freq(clk_t* clk)
+_usb_get_freq(const clk_t* clk)
 {
     volatile alg_sct_t* pll_usb;
     pll_usb = clk_regs.alg->pll_usb;
@@ -500,14 +500,14 @@ _usb_get_freq(clk_t* clk)
 }
 
 static freq_t
-_usb_set_freq(clk_t* clk, freq_t hz UNUSED)
+_usb_set_freq(const clk_t* clk, freq_t hz UNUSED)
 {
     assert(!"Not implemented");
     return clk_get_freq(clk);
 }
 
 static void
-_usb_recal(clk_t* clk UNUSED)
+_usb_recal(const clk_t* clk UNUSED)
 {
     assert(0);
 }
@@ -544,7 +544,7 @@ static struct clock usb2_clk = { CLK_OPS(USB2, usb, NULL) };
 
 /* clkox */
 static freq_t
-_clko_get_freq(clk_t* clk)
+_clko_get_freq(const clk_t* clk)
 {
     uint32_t fin = clk_get_freq(clk->parent);
     uint32_t div;
@@ -563,7 +563,7 @@ _clko_get_freq(clk_t* clk)
 }
 
 static freq_t
-_clko_set_freq(clk_t* clk, freq_t hz)
+_clko_set_freq(const clk_t* clk, freq_t hz)
 {
     uint32_t fin = clk_get_freq(clk->parent);
     uint32_t div = (fin / hz) + 1;
@@ -589,7 +589,7 @@ _clko_set_freq(clk_t* clk, freq_t hz)
 }
 
 static void
-_clko_recal(clk_t* clk UNUSED)
+_clko_recal(const clk_t* clk UNUSED)
 {
     assert(0);
 }
@@ -635,7 +635,8 @@ static struct clock clko1_clk = { CLK_OPS(CLKO1, clko, NULL) };
 static struct clock clko2_clk = { CLK_OPS(CLKO2, clko, NULL) };
 
 static int
-imx6_gate_enable(clock_sys_t* clock_sys, enum clock_gate gate, enum clock_gate_mode mode)
+imx6_gate_enable(const clock_sys_t* clock_sys, enum clock_gate gate,
+                 enum clock_gate_mode mode)
 {
     assert(clk_regs.ccm);
     assert(mode == CLKGATE_ON);
@@ -653,7 +654,7 @@ imx6_gate_enable(clock_sys_t* clock_sys, enum clock_gate gate, enum clock_gate_m
 }
 
 int
-clock_sys_init(ps_io_ops_t* o, clock_sys_t* clock_sys)
+clock_sys_init(const ps_io_ops_t* o, clock_sys_t* clock_sys)
 {
     MAP_IF_NULL(o, CCM       , clk_regs.ccm);
     MAP_IF_NULL(o, CCM_ANALOG, clk_regs.alg);
@@ -664,7 +665,7 @@ clock_sys_init(ps_io_ops_t* o, clock_sys_t* clock_sys)
 }
 
 void
-clk_print_clock_tree(clock_sys_t* sys)
+clk_print_clock_tree(const clock_sys_t* sys)
 {
     clk_t *clk = clk_get_clock(sys, CLK_MASTER);
     clk_print_tree(clk, "");

--- a/libplatsupport/src/plat/imx6/i2c.c
+++ b/libplatsupport/src/plat/imx6/i2c.c
@@ -86,7 +86,7 @@ struct i2c_bus_priv {
  ********************/
 
 static struct i2c_bus_priv*
-i2c_clk_get_priv(clk_t* clk) {
+i2c_clk_get_priv(const clk_t* clk) {
     return (struct i2c_bus_priv*)clk->priv;
 }
 
@@ -143,7 +143,7 @@ _i2c_clk_init(clk_t* clk)
 }
 
 static freq_t
-_i2c_clk_get_freq(clk_t* clk)
+_i2c_clk_get_freq(const clk_t* clk)
 {
     freq_t fin = clk_get_freq(clk->parent);
     struct i2c_bus_priv* dev = i2c_clk_get_priv(clk);
@@ -152,7 +152,7 @@ _i2c_clk_get_freq(clk_t* clk)
 }
 
 static freq_t
-_i2c_clk_set_freq(clk_t* clk, freq_t hz)
+_i2c_clk_set_freq(const clk_t* clk, freq_t hz)
 {
     freq_t fin = clk_get_freq(clk->parent);
     struct i2c_bus_priv* dev = i2c_clk_get_priv(clk);
@@ -163,7 +163,7 @@ _i2c_clk_set_freq(clk_t* clk, freq_t hz)
 }
 
 static void
-_i2c_clk_recal(clk_t* clk)
+_i2c_clk_recal(const clk_t* clk)
 {
     assert(!"IMPLEMENT ME");
 }

--- a/libplatsupport/src/plat/imx6/mux.c
+++ b/libplatsupport/src/plat/imx6/mux.c
@@ -647,7 +647,8 @@ static inline void set_mux_priv(mux_sys_t* mux, struct imx6_mux* imx6_mux)
 }
 
 static int
-imx6_mux_feature_enable(mux_sys_t* mux, enum mux_feature mux_feature, UNUSED enum mux_gpio_dir mgd)
+imx6_mux_feature_enable(mux_sys_t* mux, enum mux_feature mux_feature,
+                        enum mux_gpio_dir mgd UNUSED)
 {
     struct imx6_mux* m;
     if (mux == NULL || mux->priv == NULL) {
@@ -790,11 +791,10 @@ imx6_mux_enable_gpio(mux_sys_t* mux_sys, int gpio_id)
 }
 
 static void *imx6_mux_get_vaddr(mux_sys_t *mux) {
-    struct imx6_mux* m;
     if (mux == NULL || mux->priv == NULL) {
         return NULL;
     }
-    m = get_mux_priv(mux);
+    struct imx6_mux* m = get_mux_priv(mux);
     return (void *)m->iomuxc;
 }
 
@@ -817,7 +817,7 @@ imx6_mux_init(void* iomuxc, mux_sys_t* mux)
 }
 
 int
-mux_sys_init(ps_io_ops_t* io_ops, UNUSED void *dependencies, mux_sys_t* mux)
+mux_sys_init(ps_io_ops_t* io_ops, void *dependencies UNUSED, mux_sys_t* mux)
 {
     MAP_IF_NULL(io_ops, IMX6_IOMUXC, _mux.iomuxc);
     return imx6_mux_init_common(mux);

--- a/libplatsupport/src/plat/imx6/mux.c
+++ b/libplatsupport/src/plat/imx6/mux.c
@@ -635,7 +635,7 @@ static struct imx6_mux {
     volatile struct imx6_iomuxc_regs* iomuxc;
 } _mux;
 
-static inline struct imx6_mux* get_mux_priv(mux_sys_t* mux) {
+static inline struct imx6_mux* get_mux_priv(const mux_sys_t* mux) {
     return (struct imx6_mux*)mux->priv;
 }
 
@@ -647,7 +647,7 @@ static inline void set_mux_priv(mux_sys_t* mux, struct imx6_mux* imx6_mux)
 }
 
 static int
-imx6_mux_feature_enable(mux_sys_t* mux, enum mux_feature mux_feature,
+imx6_mux_feature_enable(const mux_sys_t* mux, enum mux_feature mux_feature,
                         enum mux_gpio_dir mgd UNUSED)
 {
     struct imx6_mux* m;
@@ -702,7 +702,7 @@ imx6_mux_feature_enable(mux_sys_t* mux, enum mux_feature mux_feature,
 }
 
 int
-imx6_mux_enable_gpio(mux_sys_t* mux_sys, int gpio_id)
+imx6_mux_enable_gpio(const mux_sys_t* mux_sys, int gpio_id)
 {
     static struct imx6_mux* m;
     volatile uint32_t *reg;
@@ -790,7 +790,7 @@ imx6_mux_enable_gpio(mux_sys_t* mux_sys, int gpio_id)
     return 0;
 }
 
-static void *imx6_mux_get_vaddr(mux_sys_t *mux) {
+static void *imx6_mux_get_vaddr(const mux_sys_t *mux) {
     if (mux == NULL || mux->priv == NULL) {
         return NULL;
     }
@@ -817,7 +817,8 @@ imx6_mux_init(void* iomuxc, mux_sys_t* mux)
 }
 
 int
-mux_sys_init(ps_io_ops_t* io_ops, void *dependencies UNUSED, mux_sys_t* mux)
+mux_sys_init(const ps_io_ops_t* io_ops, void *dependencies UNUSED,
+             mux_sys_t* mux)
 {
     MAP_IF_NULL(io_ops, IMX6_IOMUXC, _mux.iomuxc);
     return imx6_mux_init_common(mux);

--- a/libplatsupport/src/plat/imx6/mux.h
+++ b/libplatsupport/src/plat/imx6/mux.h
@@ -12,4 +12,4 @@
 
 #include <platsupport/mux.h>
 
-int imx6_mux_enable_gpio(mux_sys_t* mux, int gpio_id);
+int imx6_mux_enable_gpio(const mux_sys_t* mux, int gpio_id);

--- a/libplatsupport/src/plat/imx6/src.c
+++ b/libplatsupport/src/plat/imx6/src.c
@@ -71,7 +71,7 @@ reset_controller_assert_reset(src_dev_t* dev, enum src_rst_id id)
 }
 
 int
-reset_controller_init(enum src_id id, ps_io_ops_t* ops, src_dev_t* dev)
+reset_controller_init(enum src_id id, const ps_io_ops_t* ops, src_dev_t* dev)
 {
     assert(sizeof(struct src_regs) == 0x48);
     if (id < 0 || id >= NSRC) {

--- a/libplatsupport/src/plat/odroidc2/serial.c
+++ b/libplatsupport/src/plat/odroidc2/serial.c
@@ -31,15 +31,22 @@ int uart_getchar(ps_chardevice_t *d)
     return *REG_PTR(d->vaddr, UART_RFIFO);
 }
 
+static void internal_uart_putchar(void* vaddr, int c)
+{
+    while ((*REG_PTR(vaddr, UART_STATUS) & UART_TX_FULL) != 0) {
+        continue;
+    }
+    *REG_PTR(vaddr, UART_WFIFO) = c & 0x7f;
+}
+
 int uart_putchar(ps_chardevice_t *d, int c)
 {
-    while ((*REG_PTR(d->vaddr, UART_STATUS) & UART_TX_FULL));
-
-    /* Add character to the buffer. */
-    *REG_PTR(d->vaddr, UART_WFIFO) = c & 0x7f;
+    void* vaddr = d->vaddr;
+    /* SERIAL_AUTO_CR: Send '\r' (CR) before every '\n' (LF). */
     if (c == '\n' && (d->flags & SERIAL_AUTO_CR)) {
-        uart_putchar(d, '\r');
+        internal_uart_putchar(vaddr, '\r');
     }
+    internal_uart_putchar(vaddr, c);
 
     return c;
 }

--- a/libplatsupport/src/plat/omap3/clock.c
+++ b/libplatsupport/src/plat/omap3/clock.c
@@ -22,13 +22,14 @@ static volatile struct clock_regs {
 static struct clock master_clk = { CLK_OPS_DEFAULT(MASTER) };
 
 static int
-omap3_gate_enable(clock_sys_t* clock_sys, enum clock_gate gate, enum clock_gate_mode mode)
+omap3_gate_enable(const clock_sys_t* clock_sys, enum clock_gate gate,
+                  enum clock_gate_mode mode)
 {
     return -1;
 }
 
 int
-clock_sys_init(ps_io_ops_t* o, clock_sys_t* clock_sys)
+clock_sys_init(const ps_io_ops_t* o, clock_sys_t* clock_sys)
 {
     clock_sys->priv = (void*)&clk_regs;
     clock_sys->get_clock = &ps_get_clock;
@@ -37,9 +38,9 @@ clock_sys_init(ps_io_ops_t* o, clock_sys_t* clock_sys)
 }
 
 void
-clk_print_clock_tree(clock_sys_t* sys)
+clk_print_clock_tree(const clock_sys_t* sys)
 {
-    clk_t *clk = clk_get_clock(sys, CLK_MASTER);
+    const clk_t *clk = clk_get_clock(sys, CLK_MASTER);
     clk_print_tree(clk, "");
 }
 

--- a/libplatsupport/src/plat/omap3/mux.c
+++ b/libplatsupport/src/plat/omap3/mux.c
@@ -34,17 +34,17 @@ static inline void set_mux_priv(mux_sys_t* mux, struct omap3_mux* omap3_mux)
 }
 
 static int
-omap3_mux_feature_enable(mux_sys_t* mux, enum mux_feature mux_feature, UNUSED enum mux_gpio_dir mgd)
+omap3_mux_feature_enable(mux_sys_t* mux, enum mux_feature mux_feature,
+                         enum mux_gpio_dir mgd UNUSED)
 {
-    struct omap3_mux* m;
     if (mux == NULL || mux->priv == NULL) {
         return -1;
     }
-    m = get_mux_priv(mux);
+
+    struct omap3_mux* m UNUSED = get_mux_priv(mux);
 
     switch (mux_feature) {
     default:
-        (void)m;
         return -1;
     }
 }
@@ -58,16 +58,15 @@ omap3_mux_init_common(mux_sys_t* mux)
 }
 
 int
-omap3_mux_init(void* bank1,
+omap3_mux_init(void* bank1 UNUSED,
                mux_sys_t* mux)
 {
-    (void)bank1;
     return omap3_mux_init_common(mux);
 }
 
 int
-mux_sys_init(ps_io_ops_t* io_ops, UNUSED void *dependencies, mux_sys_t* mux)
+mux_sys_init(ps_io_ops_t* io_ops UNUSED, void *dependencies UNUSED,
+             mux_sys_t* mux)
 {
-    (void)io_ops;
     return omap3_mux_init_common(mux);
 }

--- a/libplatsupport/src/plat/omap3/mux.c
+++ b/libplatsupport/src/plat/omap3/mux.c
@@ -22,7 +22,7 @@ static struct omap3_mux {
     volatile struct omap3_mux_regs*    mux;
 } _mux;
 
-static inline struct omap3_mux* get_mux_priv(mux_sys_t* mux) {
+static inline struct omap3_mux* get_mux_priv(const mux_sys_t* mux) {
     return (struct omap3_mux*)mux->priv;
 }
 
@@ -34,7 +34,7 @@ static inline void set_mux_priv(mux_sys_t* mux, struct omap3_mux* omap3_mux)
 }
 
 static int
-omap3_mux_feature_enable(mux_sys_t* mux, enum mux_feature mux_feature,
+omap3_mux_feature_enable(const mux_sys_t* mux, enum mux_feature mux_feature,
                          enum mux_gpio_dir mgd UNUSED)
 {
     if (mux == NULL || mux->priv == NULL) {
@@ -65,7 +65,7 @@ omap3_mux_init(void* bank1 UNUSED,
 }
 
 int
-mux_sys_init(ps_io_ops_t* io_ops UNUSED, void *dependencies UNUSED,
+mux_sys_init(const ps_io_ops_t* io_ops UNUSED, void *dependencies UNUSED,
              mux_sys_t* mux)
 {
     return omap3_mux_init_common(mux);

--- a/libplatsupport/src/plat/omap3/serial.c
+++ b/libplatsupport/src/plat/omap3/serial.c
@@ -41,6 +41,8 @@ int uart_getchar(ps_chardevice_t* d)
 
 int uart_putchar(ps_chardevice_t* d, int c)
 {
+    // ToDo: check SERIAL_AUTO_CR and print CR (\r) first on LF (\n)
+
     if (*REG_PTR(d->vaddr, IMXUART_LSR) & IMXUART_LSR_TXFIFOE) {
         *REG_PTR(d->vaddr, IMXUART_THR) = c;
         return c;

--- a/libplatsupport/src/plat/pc99/serial.c
+++ b/libplatsupport/src/plat/pc99/serial.c
@@ -87,6 +87,8 @@ int uart_putchar(ps_chardevice_t* device, int c)
     /* Write out the next character. */
     ps_io_port_out(&device->ioops.io_port_ops, CONSOLE(io_port, THR), 1, c);
 
+    // ToDo: check SERIAL_AUTO_CR and print CR (\r) first on LF (\n)
+
     if (c == '\n') {
         /* If we output immediately then odds are the transmit buffer
          * will be full, so we have to wait */

--- a/libplatsupport/src/plat/qemu-arm-virt/serial.c
+++ b/libplatsupport/src/plat/qemu-arm-virt/serial.c
@@ -38,14 +38,22 @@ int uart_getchar(ps_chardevice_t *d)
     return ch;
 }
 
+static void internal_uart_putchar(void* vaddr, int c)
+{
+    while ((*REG_PTR(vaddr, UARTFR) & PL011_UARTFR_TXFF) != 0) {
+        continue
+    }
+    *REG_PTR(vaddr, UARTDR) = c;
+}
+
 int uart_putchar(ps_chardevice_t *d, int c)
 {
-    while ((*REG_PTR(d->vaddr, UARTFR) & PL011_UARTFR_TXFF) != 0);
-
-    *REG_PTR(d->vaddr, UARTDR) = c;
+    void* vaddr = d->vaddr;
+    /* SERIAL_AUTO_CR: Send '\r' (CR) before every '\n' (LF). */
     if (c == '\n' && (d->flags & SERIAL_AUTO_CR)) {
-        uart_putchar(d, '\r');
+        internal_uart_putchar(vaddr, '\r');
     }
+    internal_uart_putchar(vaddr, c);
 
     return c;
 }

--- a/libplatsupport/src/plat/rockpro64/serial.c
+++ b/libplatsupport/src/plat/rockpro64/serial.c
@@ -36,15 +36,21 @@ int uart_getchar(ps_chardevice_t *d)
     return ch;
 }
 
-int uart_putchar(ps_chardevice_t* d, int c)
+static void internal_uart_putchar(void* vaddr, int c)
 {
-    while (!(*REG_PTR(d->vaddr, LSR) & LSR_TXFIFOE)) {
+    while (!(*REG_PTR(vaddr, LSR) & LSR_TXFIFOE)) {
         continue;
     }
-    *REG_PTR(d->vaddr, THR) = c;
+    *REG_PTR(vaddr, THR) = c;
+}
+
+int uart_putchar(ps_chardevice_t* d, int c)
+{
+    void* vaddr = d->vaddr;
     if (c == '\n' && (d->flags & SERIAL_AUTO_CR)) {
-        uart_putchar(d, '\r');
+        internal_uart_putchar(vaddr, '\r');
     }
+    internal_uart_putchar(vaddr, c);
 
     return c;
 }

--- a/libplatsupport/src/plat/tk1/clock.c
+++ b/libplatsupport/src/plat/tk1/clock.c
@@ -565,14 +565,14 @@ const clk_register_t tk1_clk_registers[] = {
 };
 
 static clk_t *
-tk1_car_get_clock(clock_sys_t *cs, enum clk_id id)
+tk1_car_get_clock(const clock_sys_t *cs, enum clk_id id)
 {
     assert(cs != NULL);
     return NULL;
 }
 
 static int
-tk1_car_gate_enable(clock_sys_t* clock_sys,
+tk1_car_gate_enable(const clock_sys_t* clock_sys,
                     enum clock_gate gate, enum clock_gate_mode mode)
 {
     /* The TK1 CAR controller only supports enabling and disabling the clock
@@ -607,7 +607,7 @@ tegra_car_init(void *regs_vaddr, clock_sys_t *cs)
 }
 
 int
-clock_sys_init(ps_io_ops_t* o, clock_sys_t* clock_sys)
+clock_sys_init(const ps_io_ops_t* o, clock_sys_t* clock_sys)
 {
     void *car_vaddr = NULL;
 

--- a/libplatsupport/src/plat/tk1/mux.c
+++ b/libplatsupport/src/plat/tk1/mux.c
@@ -252,14 +252,14 @@ typedef struct tegra_mux_state {
 } tegra_mux_state_t;
 
 static const tegra_mux_state_t *
-tk1_mux_get_priv(mux_sys_t *mux_sys)
+tk1_mux_get_priv(const mux_sys_t *mux_sys)
 {
     assert(mux_sys != NULL);
     return (const tegra_mux_state_t *)mux_sys->priv;
 }
 
 static volatile uint32_t *
-tk1_mux_get_group_reg_handle_for_pin(mux_sys_t *ms, int mux_reg_index)
+tk1_mux_get_group_reg_handle_for_pin(const mux_sys_t *ms, int mux_reg_index)
 {
     volatile uint32_t   *ret;
     int                 group_offset;
@@ -272,7 +272,7 @@ tk1_mux_get_group_reg_handle_for_pin(mux_sys_t *ms, int mux_reg_index)
 }
 
 static void
-tk1_mux_set_drive_strength_for_pin(mux_sys_t *ms,
+tk1_mux_set_drive_strength_for_pin(const mux_sys_t *ms,
                                    int mux_reg_index,
                                    uint8_t drive_up_strength,
                                    uint8_t drive_down_strength)
@@ -305,7 +305,7 @@ tk1_mux_set_drive_strength_for_pin(mux_sys_t *ms,
 }
 
 static int
-tk1_mux_set_pin_params(mux_sys_t *mux, struct tk1_mux_pin_desc *desc,
+tk1_mux_set_pin_params(const mux_sys_t *mux, struct tk1_mux_pin_desc *desc,
                        enum mux_gpio_dir mux_gpio_dir)
 {
     uint32_t regval, requiredval;
@@ -516,7 +516,7 @@ tk1_mux_set_pin_unused(volatile uint32_t *regs, uint16_t mux_reg_index,
 }
 
 static int
-tk1_mux_feature_enable(mux_sys_t* mux, enum mux_feature feat,
+tk1_mux_feature_enable(const mux_sys_t* mux, enum mux_feature feat,
                        enum mux_gpio_dir mux_gpio_dir)
 {
     int error;
@@ -598,7 +598,7 @@ tk1_mux_feature_enable(mux_sys_t* mux, enum mux_feature feat,
 }
 
 static int
-tk1_mux_feature_disable(mux_sys_t* mux, enum mux_feature feat)
+tk1_mux_feature_disable(const mux_sys_t* mux, enum mux_feature feat)
 {
     tk1_mux_feature_pinmap_t *map;
     const tegra_mux_state_t *s = tk1_mux_get_priv(mux);
@@ -629,7 +629,7 @@ tk1_mux_set_all_pins_to_default_state(volatile uint32_t *mux_regs)
 
 int
 tegra_mux_init(volatile void *pinmux_misc, volatile void *pinmux_aux,
-               ps_io_ops_t *io_ops,
+               const ps_io_ops_t *io_ops,
                gpio_sys_t *gpio_sys, mux_sys_t *self)
 {
     int error;
@@ -667,7 +667,7 @@ tegra_mux_init(volatile void *pinmux_misc, volatile void *pinmux_aux,
 }
 
 int
-mux_sys_init(ps_io_ops_t *io_ops, void *dependencies, mux_sys_t *mux)
+mux_sys_init(const ps_io_ops_t *io_ops, void *dependencies, mux_sys_t *mux)
 {
     void *pinmux_misc_vaddr = NULL, *pinmux_aux_vaddr = NULL;
     gpio_sys_t *gpio_sys = (gpio_sys_t *)dependencies;

--- a/libplatsupport/src/plat/zynq7000/clock.c
+++ b/libplatsupport/src/plat/zynq7000/clock.c
@@ -422,7 +422,7 @@ zynq7000_even_divisor(uint8_t divisor)
 static struct clock master_clk = { CLK_OPS_DEFAULT(MASTER) };
 
 static uint32_t
-_decode_pll(clk_t* clk, volatile uint32_t** ctrl, volatile uint32_t** cfg)
+_decode_pll(const clk_t* clk, volatile uint32_t** ctrl, volatile uint32_t** cfg)
 {
     switch (clk->id) {
     case CLK_ARM_PLL:
@@ -445,7 +445,7 @@ _decode_pll(clk_t* clk, volatile uint32_t** ctrl, volatile uint32_t** cfg)
 
 /* PLLs */
 static freq_t
-_pll_get_freq(clk_t* clk)
+_pll_get_freq(const clk_t* clk)
 {
     volatile uint32_t* ctrl_reg;
     volatile uint32_t* cfg_reg;
@@ -467,7 +467,7 @@ _pll_get_freq(clk_t* clk)
 }
 
 static freq_t
-_pll_set_freq(clk_t* clk, freq_t hz)
+_pll_set_freq(const clk_t* clk, freq_t hz)
 {
     volatile uint32_t* ctrl_reg;
     volatile uint32_t* cfg_reg;
@@ -506,7 +506,7 @@ _pll_set_freq(clk_t* clk, freq_t hz)
 }
 
 static void
-_pll_recal(clk_t* clk UNUSED)
+_pll_recal(const clk_t* clk UNUSED)
 {
     assert(0);
 }
@@ -561,7 +561,7 @@ clk_cpu_clk_select_421(clk_t* clk)
 
 /* CPU Clocks */
 static freq_t
-_cpu_get_freq(clk_t* clk)
+_cpu_get_freq(const clk_t* clk)
 {
     uint8_t clk_621_true, divisor0;
     uint32_t divisor;
@@ -595,7 +595,7 @@ _cpu_get_freq(clk_t* clk)
 }
 
 static freq_t
-_cpu_set_freq(clk_t* clk, freq_t hz)
+_cpu_set_freq(const clk_t* clk, freq_t hz)
 {
     uint32_t fin;
     uint8_t divisor0;
@@ -619,7 +619,7 @@ _cpu_set_freq(clk_t* clk, freq_t hz)
 }
 
 static void
-_cpu_recal(clk_t* clk UNUSED)
+_cpu_recal(const clk_t* clk UNUSED)
 {
     assert(0);
 }
@@ -646,7 +646,7 @@ static struct clock cpu_1x_clk    = { CLK_OPS(CPU_1X,    cpu, NULL) };
 
 /* DDR Clocks */
 static freq_t
-_ddr_get_freq(clk_t* clk)
+_ddr_get_freq(const clk_t* clk)
 {
     uint8_t divisor0, divisor1;
     uint32_t fout, fin;
@@ -676,7 +676,7 @@ _ddr_get_freq(clk_t* clk)
 }
 
 static freq_t
-_ddr_set_freq(clk_t* clk, freq_t hz)
+_ddr_set_freq(const clk_t* clk, freq_t hz)
 {
     uint32_t fin;
     uint8_t divisor0, divisor1;
@@ -709,7 +709,7 @@ _ddr_set_freq(clk_t* clk, freq_t hz)
 }
 
 static void
-_ddr_recal(clk_t* clk UNUSED)
+_ddr_recal(const clk_t* clk UNUSED)
 {
     assert(0);
 }
@@ -733,7 +733,7 @@ static struct clock dci_clk    = { CLK_OPS(DCI,    ddr, NULL) };
 
 /* I/O Peripheral Clocks */
 static freq_t
-_aper_get_freq(clk_t* clk)
+_aper_get_freq(const clk_t* clk)
 {
     enum clk_id id;
     uint8_t divisor0, divisor1;
@@ -795,7 +795,7 @@ _aper_get_freq(clk_t* clk)
 }
 
 static freq_t
-_aper_set_freq(clk_t* clk, freq_t hz)
+_aper_set_freq(const clk_t* clk, freq_t hz)
 {
     uint32_t fin;
     uint8_t divisor0, divisor1;
@@ -850,7 +850,7 @@ _aper_set_freq(clk_t* clk, freq_t hz)
 }
 
 static void
-_aper_recal(clk_t* clk UNUSED)
+_aper_recal(const clk_t* clk UNUSED)
 {
     assert(0);
 }
@@ -882,7 +882,7 @@ static struct clock can0_clk  = { CLK_OPS(CAN0,  aper, NULL) };
 static struct clock can1_clk  = { CLK_OPS(CAN1,  aper, NULL) };
 
 static inline pl_clk_regs_t*
-get_pl_clk_regs(clk_t* clk)
+get_pl_clk_regs(const clk_t* clk)
 {
     switch (clk->id) {
     case CLK_FPGA_PL0:
@@ -900,7 +900,7 @@ get_pl_clk_regs(clk_t* clk)
 
 /* FPGA PL Clocks */
 static freq_t
-_fpga_get_freq(clk_t* clk)
+_fpga_get_freq(const clk_t* clk)
 {
     pl_clk_regs_t* regs = (pl_clk_regs_t*)clk->priv;
     uint8_t div0, div1;
@@ -912,7 +912,7 @@ _fpga_get_freq(clk_t* clk)
 }
 
 static freq_t
-_fpga_set_freq(clk_t* clk, freq_t hz)
+_fpga_set_freq(const clk_t* clk, freq_t hz)
 {
     pl_clk_regs_t* regs = (pl_clk_regs_t*)clk->priv;
     uint8_t div0, div1;
@@ -926,7 +926,7 @@ _fpga_set_freq(clk_t* clk, freq_t hz)
 }
 
 static void
-_fpga_recal(clk_t* clk UNUSED)
+_fpga_recal(const clk_t* clk UNUSED)
 {
     assert(0);
 }
@@ -960,7 +960,8 @@ static struct clock pcap_clk = { CLK_OPS_DEFAULT(PCAP) };
 static struct clock dbg_clk  = { CLK_OPS_DEFAULT(DBG ) };
 
 static int
-zynq7000_gate_enable(clock_sys_t* clock_sys, enum clock_gate gate, enum clock_gate_mode mode)
+zynq7000_gate_enable(const clock_sys_t* clock_sys, enum clock_gate gate,
+                     enum clock_gate_mode mode)
 {
     uint32_t aper_clk_ctrl;
 
@@ -977,7 +978,7 @@ zynq7000_gate_enable(clock_sys_t* clock_sys, enum clock_gate gate, enum clock_ga
 }
 
 int
-clock_sys_init(ps_io_ops_t* o, clock_sys_t* clock_sys)
+clock_sys_init(const ps_io_ops_t* o, clock_sys_t* clock_sys)
 {
     src_dev_t slcr;
     int err;
@@ -998,7 +999,7 @@ clock_sys_init(ps_io_ops_t* o, clock_sys_t* clock_sys)
 }
 
 void
-clk_print_clock_tree(clock_sys_t* sys)
+clk_print_clock_tree(const clock_sys_t* sys)
 {
     clk_t *clk = clk_get_clock(sys, CLK_MASTER);
     clk_print_tree(clk, "");

--- a/libplatsupport/src/plat/zynq7000/src.c
+++ b/libplatsupport/src/plat/zynq7000/src.c
@@ -79,7 +79,7 @@ reset_controller_get_clock_regs(src_dev_t* dev)
 }
 
 int
-reset_controller_init(enum src_id id, ps_io_ops_t* ops, src_dev_t* dev)
+reset_controller_init(enum src_id id, const ps_io_ops_t* ops, src_dev_t* dev)
 {
     /* Input bounds check */
     if (id < 0 || id >= NSRC) {

--- a/libplatsupport/src/plat/zynqmp/clock.c
+++ b/libplatsupport/src/plat/zynqmp/clock.c
@@ -22,7 +22,7 @@
 
 static struct clock cpu_1x_clk = { CLK_OPS_DEFAULT(CPU_1X) };
 
-void clk_print_clock_tree(clock_sys_t* sys)
+void clk_print_clock_tree(const clock_sys_t* sys)
 {
    clk_t *clk = clk_get_clock(sys, CLK_CPU_1X);
    clk_print_tree(clk, "");


### PR DESCRIPTION
- fix the bug that LF CR is printed instead of CR LF
- remove compiler warning about unused variable and discarded const qualifiers
- general code improvements for readability

