### PR TITLE
hifive: Fixed UART Get Character function

### DIFF
--- a/libplatsupport/src/plat/hifive/uart.c
+++ b/libplatsupport/src/plat/hifive/uart.c
@@ -51,11 +51,10 @@ uart_get_priv(ps_chardevice_t *d)
 int uart_getchar(ps_chardevice_t *d)
 {
     uart_regs_t* regs = uart_get_priv(d);
-    uint32_t reg = 0;
+    uint32_t reg = regs->rxdata;
     int c = -1;
 
-    if (!(regs->rxdata & UART_RX_DATA_EMPTY)) {
-        reg = regs->rxdata;
+    if (!(reg & UART_RX_DATA_EMPTY)) {
         c = reg & UART_RX_DATA_MASK;
     }
     return c;


### PR DESCRIPTION
The previous implementation made two reads to the rxdata register: One
to check if the Data Empty flag was set and another to grab the actual
data. However, the HiFive UART's rxdata is cleared on read. So this
would return 0xff every time. Now the rxdata is read once, stored in a
variable and operations are done against the value stored in that
variable.

Change-Id: I8f6d746293d0ce39dc5dd42eca485a944f1383a2