### PR TITLE
Do not make symbols for enums in gic(v3)

### DIFF
--- a/libplatsupport/src/arch/arm/irqchip/gic.c
+++ b/libplatsupport/src/arch/arm/irqchip/gic.c
@@ -24,12 +24,12 @@
 
 /* These offsets are in the context of the normal 'interrupts' property,
  * for the 'interrupts-extended' property, we add one to each */
-enum {
+typedef enum {
     INT_TYPE_OFFSET,
     INT_OFFSET
 } interrupt_cell_offset;
 
-enum {
+typedef enum {
     EXT_INT_CONTROLLER_OFFSET,
     EXT_INT_TYPE_OFFSET,
     EXT_INT_OFFSET

--- a/libplatsupport/src/arch/arm/irqchip/gicv3.c
+++ b/libplatsupport/src/arch/arm/irqchip/gicv3.c
@@ -34,14 +34,14 @@
 
 /* These offsets are in the context of the normal 'interrupts' property,
  * for the 'interrupts-extended' property, we add one to each */
-enum {
+typedef enum {
     INT_TYPE_OFFSET,
     INT_OFFSET,
     INT_FLAG_OFFSET,
     INT_AFFINITY_OFFSET,
 } interrupt_cell_offset;
 
-enum {
+typedef enum {
     EXT_INT_CONTROLLER_OFFSET,
     EXT_INT_TYPE_OFFSET,
     EXT_INT_OFFSET,


### PR DESCRIPTION
These conflict with each other cause cause a multiple definition error with clang 11.