### PR TITLE
Return allocated IRQ from FDT

### DIFF
--- a/libplatsupport/plat_include/rockpro64/platsupport/plat/timer.h
+++ b/libplatsupport/plat_include/rockpro64/platsupport/plat/timer.h
@@ -51,6 +51,7 @@ typedef struct {
     volatile struct rk_map *hw;
     void *rk_map_base;
     pmem_region_t pmem;
+    ps_irq_t irq;
     irq_id_t irq_id;
 } rk_t;
 


### PR DESCRIPTION
When allocating an IRQ from the FDT the IRQ that was allocated should be passed back to the caller in addition to the IRQ handler ID.

For `rockpro64`, the `ltimer` implementation for its second timer should use the IRQ number one greater that the first timer's IRQ number (rather than the first timer's IRQ handler ID).

Fixes sel4/sel4test#25.