### PR TITLE
imx7,sabre: use correct platform define

### DIFF
--- a/libplatsupport/mach_include/imx/platsupport/mach/serial.h
+++ b/libplatsupport/mach_include/imx/platsupport/mach/serial.h
@@ -27,7 +27,7 @@ enum chardev_id {
     PS_SERIAL_DEFAULT = IMX_UART2
 
 #elif defined(CONFIG_PLAT_WANDQ) || defined(CONFIG_PLAT_NITROGEN6SX) \
-      || defined(CONFIG_PLAT_IMX7) || defined(CONFIG_PLAT_IMX8MQ_EVK)
+      || defined(CONFIG_PLAT_IMX7_SABRE) || defined(CONFIG_PLAT_IMX8MQ_EVK)
 
     PS_SERIAL_DEFAULT = IMX_UART1
 


### PR DESCRIPTION
Loosely related to https://github.com/seL4/seL4/issues/254 and https://github.com/seL4/seL4/pull/255. Using CONFIG_PLAT_IMX7 feels wrong here and sets a bad example, because this refers to a SOC family and not a specific board. Using CONFIG_PLAT_IMX7_SABRE seems much more sane here. Then it will work for a specific board, but fail for any other IMX7 based platform initially. Whoever ports something has to set the proper configuration here then also.