### PR TITLE
clean up code: use const qualifier, remove casts

### DIFF
--- a/libplatsupport/include/platsupport/io.h
+++ b/libplatsupport/include/platsupport/io.h
@@ -50,7 +50,12 @@ typedef enum ps_mem_flags {
  * @param flags Memory usage flags
  * @return the virtual address at which the data at paddr can be accessed or NULL on failure
  */
-typedef void *(*ps_io_map_fn_t)(void *cookie, uintptr_t paddr, size_t size, int cached, ps_mem_flags_t flags);
+typedef void *(*ps_io_map_fn_t)(
+    void *cookie,
+    uintptr_t paddr,
+    size_t size,
+    int cached,
+    ps_mem_flags_t flags);
 
 /**
  * Unmap a previously mapped I/O memory region
@@ -59,7 +64,10 @@ typedef void *(*ps_io_map_fn_t)(void *cookie, uintptr_t paddr, size_t size, int 
  * @param vaddr a virtual address that has been returned by io_map
  * @param size the same size in bytes this memory was mapped in with originally
  */
-typedef void (*ps_io_unmap_fn_t)(void *cookie, void *vaddr, size_t size);
+typedef void (*ps_io_unmap_fn_t)(
+    void *cookie,
+    void *vaddr,
+    size_t size);
 
 typedef struct ps_io_mapper {
     void *cookie;
@@ -67,14 +75,22 @@ typedef struct ps_io_mapper {
     ps_io_unmap_fn_t io_unmap_fn;
 } ps_io_mapper_t;
 
-static inline void *ps_io_map(ps_io_mapper_t *io_mapper, uintptr_t paddr, size_t size, int cached, ps_mem_flags_t flags)
+static inline void *ps_io_map(
+    ps_io_mapper_t *io_mapper,
+    uintptr_t paddr,
+    size_t size,
+    int cached,
+    ps_mem_flags_t flags)
 {
     assert(io_mapper);
     assert(io_mapper->io_map_fn);
     return io_mapper->io_map_fn(io_mapper->cookie, paddr, size, cached, flags);
 }
 
-static inline void ps_io_unmap(ps_io_mapper_t *io_mapper, void *vaddr, size_t size)
+static inline void ps_io_unmap(
+    ps_io_mapper_t *io_mapper,
+    void *vaddr,
+    size_t size)
 {
     assert(io_mapper);
     assert(io_mapper->io_unmap_fn);
@@ -91,7 +107,11 @@ static inline void ps_io_unmap(ps_io_mapper_t *io_mapper, void *vaddr, size_t si
  *
  * @return Returns 0 on success
  */
-typedef int (*ps_io_port_in_fn_t)(void *cookie, uint32_t port, int io_size, uint32_t *result);
+typedef int (*ps_io_port_in_fn_t)(
+    void *cookie,
+    uint32_t port,
+    int io_size,
+    uint32_t *result);
 
 /**
  * Perform an architectural I/O 'out' operation (aka I/O ports on x86)
@@ -103,7 +123,11 @@ typedef int (*ps_io_port_in_fn_t)(void *cookie, uint32_t port, int io_size, uint
  *
  * @return Returns 0 on success
  */
-typedef int (*ps_io_port_out_fn_t)(void *cookie, uint32_t port, int io_size, uint32_t val);
+typedef int (*ps_io_port_out_fn_t)(
+    void *cookie,
+    uint32_t port,
+    int io_size,
+    uint32_t val);
 
 typedef struct ps_io_port_ops {
     void *cookie;
@@ -111,14 +135,22 @@ typedef struct ps_io_port_ops {
     ps_io_port_out_fn_t io_port_out_fn;
 } ps_io_port_ops_t;
 
-static inline int ps_io_port_in(ps_io_port_ops_t *port_ops, uint32_t port, int io_size, uint32_t *result)
+static inline int ps_io_port_in(
+    ps_io_port_ops_t *port_ops,
+    uint32_t port,
+    int io_size,
+    uint32_t *result)
 {
     assert(port_ops);
     assert(port_ops->io_port_in_fn);
     return port_ops->io_port_in_fn(port_ops->cookie, port, io_size, result);
 }
 
-static inline int ps_io_port_out(ps_io_port_ops_t *port_ops, uint32_t port, int io_size, uint32_t val)
+static inline int ps_io_port_out(
+    ps_io_port_ops_t *port_ops,
+    uint32_t port,
+    int io_size,
+    uint32_t val)
 {
     assert(port_ops);
     assert(port_ops->io_port_out_fn);
@@ -144,7 +176,12 @@ typedef enum dma_cache_op {
  *
  * @return NULL on failure, otherwise virtual address of allocation
  */
-typedef void *(*ps_dma_alloc_fn_t)(void *cookie, size_t size, int align, int cached, ps_mem_flags_t flags);
+typedef void *(*ps_dma_alloc_fn_t)(
+    void *cookie,
+    size_t size,
+    int align,
+    int cached,
+    ps_mem_flags_t flags);
 
 /**
  * Free a previously allocated dma memory buffer
@@ -153,7 +190,10 @@ typedef void *(*ps_dma_alloc_fn_t)(void *cookie, size_t size, int align, int cac
  * @param addr Virtual address of the memory buffer as given by the dma_alloc function
  * @param size Original size of the allocated buffer
  */
-typedef void (*ps_dma_free_fn_t)(void *cookie, void *addr, size_t size);
+typedef void (*ps_dma_free_fn_t)(
+    void *cookie,
+    void *addr,
+    size_t size);
 
 /**
  * Pin a piece of memory. This ensures it is resident and has a translation until
@@ -167,7 +207,10 @@ typedef void (*ps_dma_free_fn_t)(void *cookie, void *addr, size_t size);
  *
  * @return 0 if memory could not be pinned, otherwise physical address
  */
-typedef uintptr_t (*ps_dma_pin_fn_t)(void *cookie, void *addr, size_t size);
+typedef uintptr_t (*ps_dma_pin_fn_t)(
+    void *cookie,
+    void *addr,
+    size_t size);
 
 /**
  * Unpin a piece of memory. You should only unpin the exact same range
@@ -178,7 +221,10 @@ typedef uintptr_t (*ps_dma_pin_fn_t)(void *cookie, void *addr, size_t size);
  * @param addr Address of the memory to unpin
  * @param size Range of the memory to unpin
  */
-typedef void (*ps_dma_unpin_fn_t)(void *cookie, void *addr, size_t size);
+typedef void (*ps_dma_unpin_fn_t)(
+    void *cookie,
+    void *addr,
+    size_t size);
 
 /**
  * Perform a cache operation on a dma memory region. Pinned and unpinned
@@ -189,7 +235,11 @@ typedef void (*ps_dma_unpin_fn_t)(void *cookie, void *addr, size_t size);
  * @param size Size of the range to perform the cache operation on
  * @param op Cache operation to perform
  */
-typedef void (*ps_dma_cache_op_fn_t)(void *cookie, void *addr, size_t size, dma_cache_op_t op);
+typedef void (*ps_dma_cache_op_fn_t)(
+    void *cookie,
+    void *addr,
+    size_t size,
+    dma_cache_op_t op);
 
 typedef struct ps_dma_man {
     void *cookie;
@@ -200,52 +250,79 @@ typedef struct ps_dma_man {
     ps_dma_cache_op_fn_t dma_cache_op_fn;
 } ps_dma_man_t;
 
-static inline void *ps_dma_alloc(ps_dma_man_t *dma_man, size_t size, int align, int cache, ps_mem_flags_t flags)
+static inline void *ps_dma_alloc(
+    ps_dma_man_t *dma_man,
+    size_t size,
+    int align,
+    int cache,
+    ps_mem_flags_t flags)
 {
     assert(dma_man);
     assert(dma_man->dma_alloc_fn);
     return dma_man->dma_alloc_fn(dma_man->cookie, size, align, cache, flags);
 }
 
-static inline void ps_dma_free(ps_dma_man_t *dma_man, void *addr, size_t size)
+static inline void ps_dma_free(
+    ps_dma_man_t *dma_man,
+    void *addr,
+    size_t size)
 {
     assert(dma_man);
     assert(dma_man->dma_free_fn);
     dma_man->dma_free_fn(dma_man->cookie, addr, size);
 }
 
-static inline uintptr_t ps_dma_pin(ps_dma_man_t *dma_man, void *addr, size_t size)
+static inline uintptr_t ps_dma_pin(
+    ps_dma_man_t *dma_man,
+    void *addr,
+    size_t size)
 {
     assert(dma_man);
     assert(dma_man->dma_pin_fn);
     return dma_man->dma_pin_fn(dma_man->cookie, addr, size);
 }
 
-static inline void ps_dma_unpin(ps_dma_man_t *dma_man, void *addr, size_t size)
+static inline void ps_dma_unpin(
+    ps_dma_man_t *dma_man,
+    void *addr,
+    size_t size)
 {
     assert(dma_man);
     assert(dma_man->dma_unpin_fn);
     dma_man->dma_unpin_fn(dma_man->cookie, addr, size);
 }
 
-static inline void ps_dma_cache_op(ps_dma_man_t *dma_man, void *addr, size_t size, dma_cache_op_t op)
+static inline void ps_dma_cache_op(
+    ps_dma_man_t *dma_man,
+    void *addr,
+    size_t size,
+    dma_cache_op_t op)
 {
     assert(dma_man);
     assert(dma_man->dma_cache_op_fn);
     dma_man->dma_cache_op_fn(dma_man->cookie, addr, size, op);
 }
 
-static inline void ps_dma_cache_clean(ps_dma_man_t *dma_man, void *addr, size_t size)
+static inline void ps_dma_cache_clean(
+    ps_dma_man_t *dma_man,
+    void *addr,
+    size_t size)
 {
     ps_dma_cache_op(dma_man, addr, size, DMA_CACHE_OP_CLEAN);
 }
 
-static inline void ps_dma_cache_invalidate(ps_dma_man_t *dma_man, void *addr, size_t size)
+static inline void ps_dma_cache_invalidate(
+    ps_dma_man_t *dma_man,
+    void *addr,
+    size_t size)
 {
     ps_dma_cache_op(dma_man, addr, size, DMA_CACHE_OP_INVALIDATE);
 }
 
-static inline void ps_dma_cache_clean_invalidate(ps_dma_man_t *dma_man, void *addr, size_t size)
+static inline void ps_dma_cache_clean_invalidate(
+    ps_dma_man_t *dma_man,
+    void *addr,
+    size_t size)
 {
     ps_dma_cache_op(dma_man, addr, size, DMA_CACHE_OP_CLEAN_INVALIDATE);
 }
@@ -259,7 +336,10 @@ static inline void ps_dma_cache_clean_invalidate(ps_dma_man_t *dma_man, void *ad
  *
  * @return 0 on success, errno on error.
  */
-typedef int (*ps_malloc_fn_t)(void *cookie, size_t size, void **ptr);
+typedef int (*ps_malloc_fn_t)(
+    void *cookie,
+    size_t size,
+    void **ptr);
 
 /*
  * Allocate and zero some heap memory for the driver to use. Basically calloc.
@@ -271,7 +351,11 @@ typedef int (*ps_malloc_fn_t)(void *cookie, size_t size, void **ptr);
  *
  * @return 0 on success, errno on error.
  */
-typedef int (*ps_calloc_fn_t)(void *cookie, size_t nmemb, size_t size, void **ptr);
+typedef int (*ps_calloc_fn_t)(
+    void *cookie,
+    size_t nmemb,
+    size_t size,
+    void **ptr);
 
 /*
  * Free allocated heap memory.
@@ -282,7 +366,10 @@ typedef int (*ps_calloc_fn_t)(void *cookie, size_t nmemb, size_t size, void **pt
  *
  * @return 0 on success, errno on error.
  */
-typedef int (*ps_free_fn_t)(void *cookie, size_t size, void *ptr);
+typedef int (*ps_free_fn_t)(
+    void *cookie,
+    size_t size,
+    void *ptr);
 
 typedef struct {
     ps_malloc_fn_t malloc;
@@ -291,7 +378,10 @@ typedef struct {
     void *cookie;
 } ps_malloc_ops_t;
 
-static inline int ps_malloc(ps_malloc_ops_t *ops, size_t size, void **ptr)
+static inline int ps_malloc(
+    ps_malloc_ops_t *ops,
+    size_t size,
+    void **ptr)
 {
     if (ops == NULL) {
         ZF_LOGE("ops cannot be NULL");
@@ -317,7 +407,11 @@ static inline int ps_malloc(ps_malloc_ops_t *ops, size_t size, void **ptr)
     return ops->malloc(ops->cookie, size, ptr);
 }
 
-static inline int ps_calloc(ps_malloc_ops_t *ops, size_t nmemb, size_t size, void **ptr)
+static inline int ps_calloc(
+    ps_malloc_ops_t *ops,
+    size_t nmemb,
+    size_t size,
+    void **ptr)
 {
 
     if (ops == NULL) {
@@ -344,7 +438,9 @@ static inline int ps_calloc(ps_malloc_ops_t *ops, size_t nmemb, size_t size, voi
     return ops->calloc(ops->cookie, nmemb, size, ptr);
 }
 
-static inline int ps_free(ps_malloc_ops_t *ops, size_t size, void *ptr)
+static inline int ps_free(
+    ps_malloc_ops_t *ops,
+    size_t size, void *ptr)
 {
     if (ops == NULL) {
         ZF_LOGE("ops cannot be NULL");
@@ -371,14 +467,16 @@ static inline int ps_free(ps_malloc_ops_t *ops, size_t size, void *ptr)
  *
  * @return A pointer to a FDT object, NULL on error.
  */
-typedef char *(*ps_io_fdt_get_fn_t)(void *cookie);
+typedef char *(*ps_io_fdt_get_fn_t)(
+    void *cookie);
 
 typedef struct ps_fdt {
     void *cookie;
     ps_io_fdt_get_fn_t get_fn;
 } ps_io_fdt_t;
 
-static inline char *ps_io_fdt_get(ps_io_fdt_t *io_fdt)
+static inline char *ps_io_fdt_get(
+    ps_io_fdt_t *io_fdt)
 {
     if (io_fdt == NULL) {
         ZF_LOGE("fdt cannot be NULL");
@@ -419,20 +517,28 @@ struct ps_io_ops {
  * read_bits(&var, 8, 4) ==> 0x6
  * write_bits(&var, 8, 4, 0xC) ==> var = 0x12345C78
  */
-static inline uint32_t read_masked(volatile uint32_t *addr, uint32_t mask)
+static inline uint32_t read_masked(
+    volatile uint32_t *addr,
+    uint32_t mask)
 {
     assert(addr);
     return *addr & mask;
 }
 
-static inline void write_masked(volatile uint32_t *addr, uint32_t mask, uint32_t value)
+static inline void write_masked(
+    volatile uint32_t *addr,
+    uint32_t mask,
+    uint32_t value)
 {
     assert(addr);
     assert((value & mask) == value);
     *addr = read_masked(addr, ~mask) | value;
 }
 
-static inline uint32_t read_bits(volatile uint32_t *addr, unsigned int first_bit, unsigned int nbits)
+static inline uint32_t read_bits(
+    volatile uint32_t *addr,
+    unsigned int first_bit,
+    unsigned int nbits)
 {
     assert(addr);
     assert(first_bit < 32);
@@ -440,7 +546,11 @@ static inline uint32_t read_bits(volatile uint32_t *addr, unsigned int first_bit
     return (*addr >> first_bit) & MASK(nbits);
 }
 
-static inline void write_bits(volatile uint32_t *addr, unsigned int first_bit, unsigned int nbits, uint32_t value)
+static inline void write_bits(
+    volatile uint32_t *addr,
+    unsigned int first_bit,
+    unsigned int nbits,
+    uint32_t value)
 {
     assert(addr);
     assert(first_bit < 32);
@@ -451,4 +561,5 @@ static inline void write_bits(volatile uint32_t *addr, unsigned int first_bit, u
 /*
  * Populate a malloc ops with stdlib malloc wrappers.
  */
-int ps_new_stdlib_malloc_ops(ps_malloc_ops_t *ops);
+int ps_new_stdlib_malloc_ops(
+    ps_malloc_ops_t *ops);

--- a/libplatsupport/include/platsupport/io.h
+++ b/libplatsupport/include/platsupport/io.h
@@ -76,7 +76,7 @@ typedef struct ps_io_mapper {
 } ps_io_mapper_t;
 
 static inline void *ps_io_map(
-    ps_io_mapper_t *io_mapper,
+    const ps_io_mapper_t *io_mapper,
     uintptr_t paddr,
     size_t size,
     int cached,
@@ -88,7 +88,7 @@ static inline void *ps_io_map(
 }
 
 static inline void ps_io_unmap(
-    ps_io_mapper_t *io_mapper,
+    const ps_io_mapper_t *io_mapper,
     void *vaddr,
     size_t size)
 {
@@ -136,7 +136,7 @@ typedef struct ps_io_port_ops {
 } ps_io_port_ops_t;
 
 static inline int ps_io_port_in(
-    ps_io_port_ops_t *port_ops,
+    const ps_io_port_ops_t *port_ops,
     uint32_t port,
     int io_size,
     uint32_t *result)
@@ -147,7 +147,7 @@ static inline int ps_io_port_in(
 }
 
 static inline int ps_io_port_out(
-    ps_io_port_ops_t *port_ops,
+    const ps_io_port_ops_t *port_ops,
     uint32_t port,
     int io_size,
     uint32_t val)
@@ -251,7 +251,7 @@ typedef struct ps_dma_man {
 } ps_dma_man_t;
 
 static inline void *ps_dma_alloc(
-    ps_dma_man_t *dma_man,
+    const ps_dma_man_t *dma_man,
     size_t size,
     int align,
     int cache,
@@ -263,7 +263,7 @@ static inline void *ps_dma_alloc(
 }
 
 static inline void ps_dma_free(
-    ps_dma_man_t *dma_man,
+    const ps_dma_man_t *dma_man,
     void *addr,
     size_t size)
 {
@@ -273,7 +273,7 @@ static inline void ps_dma_free(
 }
 
 static inline uintptr_t ps_dma_pin(
-    ps_dma_man_t *dma_man,
+    const ps_dma_man_t *dma_man,
     void *addr,
     size_t size)
 {
@@ -283,7 +283,7 @@ static inline uintptr_t ps_dma_pin(
 }
 
 static inline void ps_dma_unpin(
-    ps_dma_man_t *dma_man,
+    const ps_dma_man_t *dma_man,
     void *addr,
     size_t size)
 {
@@ -293,7 +293,7 @@ static inline void ps_dma_unpin(
 }
 
 static inline void ps_dma_cache_op(
-    ps_dma_man_t *dma_man,
+    const ps_dma_man_t *dma_man,
     void *addr,
     size_t size,
     dma_cache_op_t op)
@@ -304,7 +304,7 @@ static inline void ps_dma_cache_op(
 }
 
 static inline void ps_dma_cache_clean(
-    ps_dma_man_t *dma_man,
+    const ps_dma_man_t *dma_man,
     void *addr,
     size_t size)
 {
@@ -312,7 +312,7 @@ static inline void ps_dma_cache_clean(
 }
 
 static inline void ps_dma_cache_invalidate(
-    ps_dma_man_t *dma_man,
+    const ps_dma_man_t *dma_man,
     void *addr,
     size_t size)
 {
@@ -320,7 +320,7 @@ static inline void ps_dma_cache_invalidate(
 }
 
 static inline void ps_dma_cache_clean_invalidate(
-    ps_dma_man_t *dma_man,
+    const ps_dma_man_t *dma_man,
     void *addr,
     size_t size)
 {
@@ -379,7 +379,7 @@ typedef struct {
 } ps_malloc_ops_t;
 
 static inline int ps_malloc(
-    ps_malloc_ops_t *ops,
+    const ps_malloc_ops_t *ops,
     size_t size,
     void **ptr)
 {
@@ -408,7 +408,7 @@ static inline int ps_malloc(
 }
 
 static inline int ps_calloc(
-    ps_malloc_ops_t *ops,
+    const ps_malloc_ops_t *ops,
     size_t nmemb,
     size_t size,
     void **ptr)
@@ -439,7 +439,7 @@ static inline int ps_calloc(
 }
 
 static inline int ps_free(
-    ps_malloc_ops_t *ops,
+    const ps_malloc_ops_t *ops,
     size_t size, void *ptr)
 {
     if (ops == NULL) {
@@ -476,7 +476,7 @@ typedef struct ps_fdt {
 } ps_io_fdt_t;
 
 static inline char *ps_io_fdt_get(
-    ps_io_fdt_t *io_fdt)
+    const  ps_io_fdt_t *io_fdt)
 {
     if (io_fdt == NULL) {
         ZF_LOGE("fdt cannot be NULL");

--- a/libplatsupport/src/chardev.h
+++ b/libplatsupport/src/chardev.h
@@ -30,8 +30,8 @@ static inline void *chardev_map(
     const ps_io_ops_t *ops)
 {
     return ps_io_map(
-               (ps_io_mapper_t *)&ops->io_mapper,
-               (uintptr_t)dev->paddr,
+               &ops->io_mapper,
+               dev->paddr,
                dev->size,
                0, // map uncached
                PS_MEM_NORMAL);

--- a/libplatsupport/src/chardev.h
+++ b/libplatsupport/src/chardev.h
@@ -18,23 +18,53 @@
 struct dev_defn {
     enum chardev_id id;
     uintptr_t paddr;
-    int   size;
-    const int* irqs;
-    int (*init_fn)(const struct dev_defn* defn,
-                   const ps_io_ops_t* ops,
-                   struct ps_chardevice* dev);
+    int size;
+    const int *irqs;
+    int (*init_fn)(const struct dev_defn *defn,
+                   const ps_io_ops_t *ops,
+                   struct ps_chardevice *dev);
 };
 
-static inline void*
-chardev_map(const struct dev_defn* d, const ps_io_ops_t* o)
+static inline void *chardev_map(
+    const struct dev_defn *dev,
+    const ps_io_ops_t *ops)
 {
-    return ps_io_map((ps_io_mapper_t*)&o->io_mapper, (uintptr_t) d->paddr, d->size, 0, PS_MEM_NORMAL);
+    return ps_io_map(
+               (ps_io_mapper_t *)&ops->io_mapper,
+               (uintptr_t)dev->paddr,
+               dev->size,
+               0, // map uncached
+               PS_MEM_NORMAL);
 }
 
-int uart_init(const struct dev_defn* defn, const ps_io_ops_t* ops, ps_chardevice_t* dev);
-int uart_static_init(void *vaddr, const ps_io_ops_t* ops, ps_chardevice_t* dev);
-ssize_t uart_write(ps_chardevice_t* d, const void* vdata, size_t count, chardev_callback_t rcb UNUSED, void* token UNUSED);
-ssize_t uart_read(ps_chardevice_t* d, void* vdata, size_t count, chardev_callback_t rcb UNUSED, void* token UNUSED);
-int uart_getchar(ps_chardevice_t *d);
-int uart_putchar(ps_chardevice_t* d, int c);
+int uart_init(
+    const struct dev_defn *defn,
+    const ps_io_ops_t *ops,
+    ps_chardevice_t *dev);
+
+int uart_static_init(
+    void *vaddr,
+    const ps_io_ops_t *ops,
+    ps_chardevice_t *dev);
+
+ssize_t uart_write(
+    ps_chardevice_t *dev,
+    const void *vdata,
+    size_t count,
+    chardev_callback_t rcb UNUSED,
+    void *token UNUSED);
+
+ssize_t uart_read(
+    ps_chardevice_t *dev,
+    void *vdata,
+    size_t count,
+    chardev_callback_t rcb UNUSED,
+    void *token UNUSED);
+
+int uart_getchar(
+    ps_chardevice_t *dev);
+
+int uart_putchar(
+    ps_chardevice_t *dev,
+    int c);
 


### PR DESCRIPTION
Cleaning up the code a bit. When const qualifier is used everywhere, there is no need to cast explicitly.