### PR TITLE
license: stricter SPDX syntax for bamboo

### DIFF
--- a/.licenseignore
+++ b/.licenseignore
@@ -1,0 +1,6 @@
+# Copyright 2019, Data61, CSIRO (ABN 41 687 119 230)
+# SPDX-License-Identifier: BSD-2-Clause
+
+# This is for the old D61 license check too that bamboo is still running
+
+libfdt/LICENSE

--- a/libethdrivers/src/plat/zynq7000/uboot/marvell.c
+++ b/libethdrivers/src/plat/zynq7000/uboot/marvell.c
@@ -1,11 +1,12 @@
 /*
  * Marvell PHY drivers
  *
- * SPDX-License-Identifier:	GPL-2.0-or-later
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * Copyright 2010-2011 Freescale Semiconductor, Inc.
  * author Andy Fleming
  */
+
 #include "config.h"
 #include "common.h"
 #include "phy.h"

--- a/libethdrivers/src/plat/zynq7000/uboot/net.h
+++ b/libethdrivers/src/plat/zynq7000/uboot/net.h
@@ -3,7 +3,7 @@
  *
  *	Copyright 1994 - 2000 Neil Russell.
  *	(See License)
- *	SPDX-License-Identifier:	GPL-2.0-only
+ *	SPDX-License-Identifier: GPL-2.0-only
  *
  * History
  *	9/16/00	  bor  adapted to TQM823L/STK8xxL board, RARP/TFTP boot added

--- a/libethdrivers/src/plat/zynq7000/uboot/netdev.h
+++ b/libethdrivers/src/plat/zynq7000/uboot/netdev.h
@@ -2,7 +2,7 @@
  * (C) Copyright 2008
  * Benjamin Warren, biggerbadderben@gmail.com
  *
- * SPDX-License-Identifier:	GPL-2.0-or-later
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 /*

--- a/libethdrivers/src/plat/zynq7000/uboot/phy.c
+++ b/libethdrivers/src/plat/zynq7000/uboot/phy.c
@@ -1,7 +1,7 @@
 /*
  * Generic PHY Management code
  *
- * SPDX-License-Identifier:	GPL-2.0-or-later
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * Copyright 2011 Freescale Semiconductor, Inc.
  * author Andy Fleming

--- a/libethdrivers/src/plat/zynq7000/uboot/phy.h
+++ b/libethdrivers/src/plat/zynq7000/uboot/phy.h
@@ -2,7 +2,7 @@
  * Copyright 2011 Freescale Semiconductor, Inc.
  *	Andy Fleming <afleming@gmail.com>
  *
- * SPDX-License-Identifier:	GPL-2.0-or-later
+ * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * This file pretty much stolen from Linux's mii.h/ethtool.h/phy.h
  */

--- a/libethdrivers/src/plat/zynq7000/uboot/system.h
+++ b/libethdrivers/src/plat/zynq7000/uboot/system.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identifier:	GPL-2.0-or-later
+ * SPDX-License-Identifier: GPL-2.0-or-later
  * Copyright Wolfgang Denk, DENX Software Engineering, wd@denx.de.
  */
 

--- a/libethdrivers/src/plat/zynq7000/uboot/zynq-common.h
+++ b/libethdrivers/src/plat/zynq7000/uboot/zynq-common.h
@@ -4,7 +4,7 @@
  *
  * Common configuration options for all Zynq boards.
  *
- * SPDX-License-Identifier:	GPL-2.0-or-later
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #ifndef __CONFIG_ZYNQ_COMMON_H

--- a/libethdrivers/src/plat/zynq7000/uboot/zynq_zc70x.h
+++ b/libethdrivers/src/plat/zynq7000/uboot/zynq_zc70x.h
@@ -4,7 +4,7 @@
  * Configuration settings for the Xilinx Zynq ZC702 and ZC706 boards
  * See zynq-common.h for Zynq common configs
  *
- * SPDX-License-Identifier:	GPL-2.0-or-later
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #ifndef __CONFIG_ZYNQ_ZC70X_H


### PR DESCRIPTION
The old license checker that is still running on bamboo needs strictly one space character after the `:`.

That old license checker should be retired when everything is converted, but currently we still need to support both.

