### PR TITLE
trivial: fix comment terminator

### DIFF
--- a/libplatsupport/plat_include/polarfire/platsupport/plat/serial.h
+++ b/libplatsupport/plat_include/polarfire/platsupport/plat/serial.h
@@ -79,8 +79,8 @@ typedef volatile struct uart uart_regs_t;
 #define DEFAULT_SERIAL_PADDR UART3_PADDR
 #define DEFAULT_SERIAL_INTERRUPT UART3_IRQ
 
-/* Relevant Register Masks *
-/
+/* Relevant Register Masks */
+
 /* Line Control Register */
 #define LCR_WORD_LEN_5                  0b00
 #define LCR_WORD_LEN_6                  0b01

--- a/libplatsupport/plat_include/spike/platsupport/plat/serial.h
+++ b/libplatsupport/plat_include/spike/platsupport/plat/serial.h
@@ -6,12 +6,12 @@
 #pragma once
 
 
-enum chardev_id {                      
-    PS_SERIAL0,                        
-    PS_SERIAL1,                        
-    /* defaults */                     
-    PS_SERIAL_DEFAULT = PS_SERIAL1     
-};                                     
+enum chardev_id {
+    PS_SERIAL0,
+    PS_SERIAL1,
+    /* defaults */
+    PS_SERIAL_DEFAULT = PS_SERIAL1
+};
 
 #define PS_SERIAL_DEFAULT 0
 

--- a/libplatsupport/src/plat/spike/serial.c
+++ b/libplatsupport/src/plat/spike/serial.c
@@ -9,9 +9,10 @@
 #include <string.h>
 
 
-int uart_init(const struct dev_defn* defn,
-              const ps_io_ops_t* ops,
-              ps_chardevice_t* dev)
+int uart_init(
+    const struct dev_defn *defn UNUSED,
+    const ps_io_ops_t *ops UNUSED,
+    ps_chardevice_t *dev UNUSED)
 {
     return 0;
 }

--- a/libplatsupport/src/plat/spike/serial.c
+++ b/libplatsupport/src/plat/spike/serial.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <platsupport/serial.h>
 #include <platsupport/plat/serial.h>
+#include "../../chardev.h"
 #include <string.h>
 
 


### PR DESCRIPTION
avoid error due to misaligned comment termiator
```
In file included from .../sel4_util_libs/libplatsupport/include/platsupport/chardev.h:14,
                 from .../sel4_libs/libsel4platsupport/include/sel4platsupport/platsupport.h:13,
                 from .../main/camkes.c:14:
.../sel4_util_libs/libplatsupport/plat_include/polarfire/platsupport/plat/serial.h:84:1: error: "/*" within comment [-Werror=comment]
 /* Line Control Register */
```