### PR TITLE
use const qualifier for libcpio and libelf wherever possible

### DIFF
--- a/libcpio/include/cpio/cpio.h
+++ b/libcpio/include/cpio/cpio.h
@@ -49,7 +49,7 @@ struct cpio_info {
  * @return             The location of the file in memory; NULL if the index
  *                     exceeds the number of files in the CPIO archive.
  */
-void *cpio_get_entry(void *archive, unsigned long len, int index, const char **name, unsigned long *size);
+const void *cpio_get_entry(const void *archive, unsigned long len, int index, const char **name, unsigned long *size);
 
 /**
  * Retrieve file information from a provided file name
@@ -59,7 +59,7 @@ void *cpio_get_entry(void *archive, unsigned long len, int index, const char **n
  * @return             The location of the file in memory; NULL if the file
  *                     does not exist.
  */
-void *cpio_get_file(void *archive, unsigned long len, const char *name, unsigned long *size);
+const void *cpio_get_file(const void *archive, unsigned long len, const char *name, unsigned long *size);
 
 /**
  * Retrieves information about the provided CPIO archive
@@ -67,7 +67,7 @@ void *cpio_get_file(void *archive, unsigned long len, const char *name, unsigned
  * @param[out] info    A CPIO info structure to populate
  * @return             Non-zero on error.
  */
-int cpio_info(void *archive, unsigned long len, struct cpio_info *info);
+int cpio_info(const void *archive, unsigned long len, struct cpio_info *info);
 
 /**
  * Writes the list of file names contained within a CPIO archive into
@@ -76,5 +76,5 @@ int cpio_info(void *archive, unsigned long len, struct cpio_info *info);
  * @param[in] buf      A memory location to store the CPIO file list to
  * @param[in] buf_len  The length of the provided buf
  */
-void cpio_ls(void *archive, unsigned long len, char **buf, unsigned long buf_len);
+void cpio_ls(const void *archive, unsigned long len, char **buf, unsigned long buf_len);
 

--- a/libcpio/src/cpio.c
+++ b/libcpio/src/cpio.c
@@ -11,10 +11,10 @@
 #endif
 
 struct cpio_header_info {
-    const char *filename;
+    char const *filename;
     unsigned long filesize;
-    void *data;
-    struct cpio_header *next;
+    const void *data;
+    const struct cpio_header *next;
 };
 
 /* Align 'n' up to the value 'align', which must be a power of two. */
@@ -24,7 +24,7 @@ static unsigned long align_up(unsigned long n, unsigned long align)
 }
 
 /* Parse an ASCII hex string into an integer. */
-static unsigned long parse_hex_str(char *s, unsigned int max_len)
+static unsigned long parse_hex_str(const char *s, unsigned int max_len)
 {
     unsigned long r = 0;
     unsigned long i;
@@ -88,7 +88,7 @@ static unsigned int cpio_strlen(const char *str)
 }
 
 /* Calculate the remaining length in a CPIO file after reading a header. */
-static unsigned long cpio_len_next(unsigned long len, void *prev, void *next)
+static unsigned long cpio_len_next(unsigned long len, const void *prev, const void *next)
 {
     unsigned long diff = (unsigned long)(next - prev);
     if (len < diff) {
@@ -102,14 +102,14 @@ static unsigned long cpio_len_next(unsigned long len, void *prev, void *next)
  *
  * Return -1 if the header is not valid, 1 if it is EOF.
  */
-int cpio_parse_header(struct cpio_header *archive, unsigned long len,
+int cpio_parse_header(const struct cpio_header *archive, unsigned long len,
                       struct cpio_header_info *info)
 {
     const char *filename;
     unsigned long filesize;
     unsigned long filename_length;
-    void *data;
-    struct cpio_header *next;
+    const void *data;
+    const struct cpio_header *next;
 
     /* Ensure header is accessible */
     if (len < sizeof(struct cpio_header)) {
@@ -165,9 +165,9 @@ int cpio_parse_header(struct cpio_header *archive, unsigned long len,
  *
  * Runs in O(n) time.
  */
-void *cpio_get_entry(void *archive, unsigned long len, int n, const char **name, unsigned long *size)
+const void *cpio_get_entry(const void *archive, unsigned long len, int n, const char **name, unsigned long *size)
 {
-    struct cpio_header *header = archive;
+    const struct cpio_header *header = archive;
     struct cpio_header_info header_info;
 
     /* Find n'th entry. */
@@ -197,9 +197,9 @@ void *cpio_get_entry(void *archive, unsigned long len, int n, const char **name,
  *
  * Runs in O(n) time.
  */
-void *cpio_get_file(void *archive, unsigned long len, const char *name, unsigned long *size)
+const void *cpio_get_file(const void *archive, unsigned long len, const char *name, unsigned long *size)
 {
-    struct cpio_header *header = archive;
+    const struct cpio_header *header = archive;
     struct cpio_header_info header_info;
 
     /* Find n'th entry. */
@@ -221,9 +221,9 @@ void *cpio_get_file(void *archive, unsigned long len, const char *name, unsigned
     return header_info.data;
 }
 
-int cpio_info(void *archive, unsigned long len, struct cpio_info *info)
+int cpio_info(const void *archive, unsigned long len, struct cpio_info *info)
 {
-    struct cpio_header *header;
+    const struct cpio_header *header;
     unsigned long current_path_sz;
     struct cpio_header_info header_info;
 
@@ -256,9 +256,9 @@ int cpio_info(void *archive, unsigned long len, struct cpio_info *info)
     return 0;
 }
 
-void cpio_ls(void *archive, unsigned long len, char **buf, unsigned long buf_len)
+void cpio_ls(const void *archive, unsigned long len, char **buf, unsigned long buf_len)
 {
-    struct cpio_header *header;
+    const struct cpio_header *header;
     struct cpio_header_info header_info;
 
     header = archive;

--- a/libcpio/src/cpio.c
+++ b/libcpio/src/cpio.c
@@ -69,7 +69,8 @@ static int cpio_strncmp(const char *a, const char *b, unsigned long n)
  * This is an implementation of string copy because, cpi doesn't want to
  * use string.h.
  */
-static char* cpio_strcpy(char *to, const char *from) {
+static char *cpio_strcpy(char *to, const char *from)
+{
     char *save = to;
     while (*from != 0) {
         *to = *from;
@@ -79,15 +80,17 @@ static char* cpio_strcpy(char *to, const char *from) {
     return save;
 }
 
-static unsigned int cpio_strlen(const char *str) {
+static unsigned int cpio_strlen(const char *str)
+{
     const char *s;
     for (s = str; *s; ++s) {}
     return (s - str);
 }
 
 /* Calculate the remaining length in a CPIO file after reading a header. */
-static unsigned long cpio_len_next(unsigned long len, void *prev, void *next) {
-    unsigned long diff = (unsigned long) (next - prev);
+static unsigned long cpio_len_next(unsigned long len, void *prev, void *next)
+{
+    unsigned long diff = (unsigned long)(next - prev);
     if (len < diff) {
         return 0;
     }
@@ -100,7 +103,7 @@ static unsigned long cpio_len_next(unsigned long len, void *prev, void *next) {
  * Return -1 if the header is not valid, 1 if it is EOF.
  */
 int cpio_parse_header(struct cpio_header *archive, unsigned long len,
-        struct cpio_header_info *info)
+                      struct cpio_header_info *info)
 {
     const char *filename;
     unsigned long filesize;
@@ -135,13 +138,13 @@ int cpio_parse_header(struct cpio_header *archive, unsigned long len,
 
     /* Ensure filename is not the trailer indicating EOF. */
     if (filename_length >= sizeof(CPIO_FOOTER_MAGIC) && cpio_strncmp(filename,
-                CPIO_FOOTER_MAGIC, sizeof(CPIO_FOOTER_MAGIC)) == 0) {
+                                                                     CPIO_FOOTER_MAGIC, sizeof(CPIO_FOOTER_MAGIC)) == 0) {
         return 1;
     }
 
     /* Find offset to data. */
     data = (void *) align_up((unsigned long) archive + sizeof(struct cpio_header) +
-            filename_length, CPIO_ALIGNMENT);
+                             filename_length, CPIO_ALIGNMENT);
     next = (struct cpio_header *) align_up((unsigned long) data + filesize, CPIO_ALIGNMENT);
 
     if (info) {
@@ -218,12 +221,15 @@ void *cpio_get_file(void *archive, unsigned long len, const char *name, unsigned
     return header_info.data;
 }
 
-int cpio_info(void *archive, unsigned long len, struct cpio_info *info) {
+int cpio_info(void *archive, unsigned long len, struct cpio_info *info)
+{
     struct cpio_header *header;
     unsigned long current_path_sz;
     struct cpio_header_info header_info;
 
-    if (info == NULL) return 1;
+    if (info == NULL) {
+        return 1;
+    }
     info->file_count = 0;
     info->max_path_sz = 0;
 
@@ -250,7 +256,8 @@ int cpio_info(void *archive, unsigned long len, struct cpio_info *info) {
     return 0;
 }
 
-void cpio_ls(void *archive, unsigned long len, char **buf, unsigned long buf_len) {
+void cpio_ls(void *archive, unsigned long len, char **buf, unsigned long buf_len)
+{
     struct cpio_header *header;
     struct cpio_header_info header_info;
 
@@ -258,7 +265,9 @@ void cpio_ls(void *archive, unsigned long len, char **buf, unsigned long buf_len
     for (unsigned long i = 0; i < buf_len; i++) {
         int error = cpio_parse_header(header, len, &header_info);
         // Break on an error or nothing left to read.
-        if (error) break;
+        if (error) {
+            break;
+        }
         cpio_strcpy(buf[i], header_info.filename);
         len = cpio_len_next(len, header, header_info.next);
         header = header_info.next;

--- a/libelf/include/elf/elf.h
+++ b/libelf/include/elf/elf.h
@@ -33,7 +33,7 @@ ELF file into memory.
 #include <elf.h>
 
 struct elf {
-    void *elfFile;
+    void const *elfFile;
     size_t elfSize;
     unsigned char elfClass; /* 32-bit or 64-bit */
 };
@@ -58,7 +58,7 @@ typedef enum elf_addr_type elf_addr_type_t;
  *
  * \return 0 on success, otherwise < 0
  */
-int elf_newFile(void *file, size_t size, elf_t *res);
+int elf_newFile(const void *file, size_t size, elf_t *res);
 
 /**
  * Initialises and elf_t structure and checks that the ELF file is valid.
@@ -77,7 +77,7 @@ int elf_newFile(void *file, size_t size, elf_t *res);
  *
  * \return 0 on success, otherwise < 0
  */
-int elf_newFile_maybe_unsafe(void *file, size_t size, bool check_pht, bool check_st, elf_t *res);
+int elf_newFile_maybe_unsafe(const void *file, size_t size, bool check_pht, bool check_st, elf_t *res);
 
 /**
  * Checks that file starts with the ELF magic number.
@@ -87,7 +87,7 @@ int elf_newFile_maybe_unsafe(void *file, size_t size, bool check_pht, bool check
  *
  * \return 0 on success, otherwise < 0
  */
-int elf_check_magic(char *file);
+int elf_check_magic(const char *file);
 
 /**
  * Checks that elfFile points to an ELF file with a valid ELF header.
@@ -105,7 +105,7 @@ int elf_checkFile(elf_t *elfFile);
  *
  * \return 0 on success, otherwise < 0
  */
-int elf_checkProgramHeaderTable(elf_t *elfFile);
+int elf_checkProgramHeaderTable(const elf_t *elfFile);
 
 /**
  * Checks that elfFile points to an ELF file with a valid section table.
@@ -114,7 +114,7 @@ int elf_checkProgramHeaderTable(elf_t *elfFile);
  *
  * \return 0 on success, otherwise < 0
  */
-int elf_checkSectionTable(elf_t *elfFile);
+int elf_checkSectionTable(const elf_t *elfFile);
 
 /**
  * Find the entry point of an ELF file.
@@ -123,7 +123,7 @@ int elf_checkSectionTable(elf_t *elfFile);
  *
  * \return The entry point address.
  */
-uintptr_t elf_getEntryPoint(elf_t *elfFile);
+uintptr_t elf_getEntryPoint(const elf_t *elfFile);
 
 /**
  * Determine number of program headers in an ELF file.
@@ -132,7 +132,7 @@ uintptr_t elf_getEntryPoint(elf_t *elfFile);
  *
  * \return Number of program headers in the ELF file.
  */
-size_t elf_getNumProgramHeaders(elf_t *elfFile);
+size_t elf_getNumProgramHeaders(const elf_t *elfFile);
 
 /**
  * Determine number of sections in an ELF file.
@@ -141,7 +141,7 @@ size_t elf_getNumProgramHeaders(elf_t *elfFile);
  *
  * \return Number of sections in the ELF file.
  */
-size_t elf_getNumSections(elf_t *elfFile);
+size_t elf_getNumSections(const elf_t *elfFile);
 
 /**
  * Get the index of the section header string table of an ELF file.
@@ -150,7 +150,7 @@ size_t elf_getNumSections(elf_t *elfFile);
  *
  * \return The index of the section header string table.
  */
-size_t elf_getSectionStringTableIndex(elf_t *elf);
+size_t elf_getSectionStringTableIndex(const elf_t *elf);
 
 /**
  * Get a string table section of an ELF file.
@@ -160,7 +160,7 @@ size_t elf_getSectionStringTableIndex(elf_t *elf);
  *
  * \return The string table, or NULL if the section is not a string table.
  */
-const char *elf_getStringTable(elf_t *elfFile, size_t string_segment);
+const char *elf_getStringTable(const elf_t *elfFile, size_t string_segment);
 
 /**
  * Get the string table for section header names.
@@ -169,7 +169,7 @@ const char *elf_getStringTable(elf_t *elfFile, size_t string_segment);
  *
  * \return The string table, or NULL if there is no table.
  */
-const char *elf_getSectionStringTable(elf_t *elfFile);
+const char *elf_getSectionStringTable(const elf_t *elfFile);
 
 
 /* Section header functions */
@@ -181,7 +181,7 @@ const char *elf_getSectionStringTable(elf_t *elfFile);
  *
  * \return The section, or NULL if there is no section.
  */
-void *elf_getSection(elf_t *elfFile, size_t i);
+const void *elf_getSection(const elf_t *elfFile, size_t i);
 
 /**
  * Get the section of an ELF file with a given name.
@@ -192,7 +192,7 @@ void *elf_getSection(elf_t *elfFile, size_t i);
  *
  * \return The section, or NULL if there is no section.
  */
-void *elf_getSectionNamed(elf_t *elfFile, const char *str, size_t *i);
+const void *elf_getSectionNamed(const elf_t *elfFile, const char *str, size_t *i);
 
 /**
  * Return the name of a given section.
@@ -202,7 +202,7 @@ void *elf_getSectionNamed(elf_t *elfFile, const char *str, size_t *i);
  *
  * \return The name of a given section.
  */
-const char *elf_getSectionName(elf_t *elfFile, size_t i);
+const char *elf_getSectionName(const elf_t *elfFile, size_t i);
 
 /**
  * Return the offset to the name of a given section in the section header
@@ -214,7 +214,7 @@ const char *elf_getSectionName(elf_t *elfFile, size_t i);
  * \return The offset to the name of a given section in the section header
  * string table.
  */
-size_t elf_getSectionNameOffset(elf_t *elfFile, size_t i);
+size_t elf_getSectionNameOffset(const elf_t *elfFile, size_t i);
 
 /**
  * Return the type of a given section
@@ -224,7 +224,7 @@ size_t elf_getSectionNameOffset(elf_t *elfFile, size_t i);
  *
  * \return The type of a given section.
  */
-uint32_t elf_getSectionType(elf_t *elfFile, size_t i);
+uint32_t elf_getSectionType(const elf_t *elfFile, size_t i);
 
 /**
  * Return the flags of a given section
@@ -234,7 +234,7 @@ uint32_t elf_getSectionType(elf_t *elfFile, size_t i);
  *
  * \return The flags of a given section.
  */
-size_t elf_getSectionFlags(elf_t *elfFile, size_t i);
+size_t elf_getSectionFlags(const elf_t *elfFile, size_t i);
 
 /**
  * Return the address of a given section
@@ -244,7 +244,7 @@ size_t elf_getSectionFlags(elf_t *elfFile, size_t i);
  *
  * \return The address of a given section.
  */
-uintptr_t elf_getSectionAddr(elf_t *elfFile, size_t i);
+uintptr_t elf_getSectionAddr(const elf_t *elfFile, size_t i);
 
 /**
  * Return the offset of a given section
@@ -254,7 +254,7 @@ uintptr_t elf_getSectionAddr(elf_t *elfFile, size_t i);
  *
  * \return The offset of a given section.
  */
-size_t elf_getSectionOffset(elf_t *elfFile, size_t i);
+size_t elf_getSectionOffset(const elf_t *elfFile, size_t i);
 
 /**
  * Return the size of a given section
@@ -264,7 +264,7 @@ size_t elf_getSectionOffset(elf_t *elfFile, size_t i);
  *
  * \return The size of a given section.
  */
-size_t elf_getSectionSize(elf_t *elfFile, size_t i);
+size_t elf_getSectionSize(const elf_t *elfFile, size_t i);
 
 /**
  * Return the related section index of a given section
@@ -274,7 +274,7 @@ size_t elf_getSectionSize(elf_t *elfFile, size_t i);
  *
  * \return The related section index of a given section.
  */
-uint32_t elf_getSectionLink(elf_t *elfFile, size_t i);
+uint32_t elf_getSectionLink(const elf_t *elfFile, size_t i);
 
 /**
  * Return extra information of a given section
@@ -284,7 +284,7 @@ uint32_t elf_getSectionLink(elf_t *elfFile, size_t i);
  *
  * \return Extra information of a given section.
  */
-uint32_t elf_getSectionInfo(elf_t *elfFile, size_t i);
+uint32_t elf_getSectionInfo(const elf_t *elfFile, size_t i);
 
 /**
  * Return the alignment of a given section
@@ -294,7 +294,7 @@ uint32_t elf_getSectionInfo(elf_t *elfFile, size_t i);
  *
  * \return The alignment of a given section.
  */
-size_t elf_getSectionAddrAlign(elf_t *elfFile, size_t i);
+size_t elf_getSectionAddrAlign(const elf_t *elfFile, size_t i);
 
 /**
  * Return the entry size of a given section
@@ -304,7 +304,7 @@ size_t elf_getSectionAddrAlign(elf_t *elfFile, size_t i);
  *
  * \return The entry size of a given section.
  */
-size_t elf_getSectionEntrySize(elf_t *elfFile, size_t i);
+size_t elf_getSectionEntrySize(const elf_t *elfFile, size_t i);
 
 
 /* Program header functions */
@@ -317,7 +317,7 @@ size_t elf_getSectionEntrySize(elf_t *elfFile, size_t i);
  *
  * \return Pointer to the segment data
  */
-void *elf_getProgramSegment(elf_t *elf, size_t ph);
+const void *elf_getProgramSegment(const elf_t *elf, size_t ph);
 
 /**
  * Return the type for a given program header.
@@ -327,7 +327,7 @@ void *elf_getProgramSegment(elf_t *elf, size_t ph);
  *
  * \return The type of a given program header.
  */
-uint32_t elf_getProgramHeaderType(elf_t *elfFile, size_t ph);
+uint32_t elf_getProgramHeaderType(const elf_t *elfFile, size_t ph);
 
 /**
  * Return the segment offset for a given program header.
@@ -337,7 +337,7 @@ uint32_t elf_getProgramHeaderType(elf_t *elfFile, size_t ph);
  *
  * \return The offset of this program header from the start of the file.
  */
-size_t elf_getProgramHeaderOffset(elf_t *elfFile, size_t ph);
+size_t elf_getProgramHeaderOffset(const elf_t *elfFile, size_t ph);
 
 /**
  * Return the base virtual address of given program header.
@@ -347,7 +347,7 @@ size_t elf_getProgramHeaderOffset(elf_t *elfFile, size_t ph);
  *
  * \return The memory size of the specified program header.
  */
-uintptr_t elf_getProgramHeaderVaddr(elf_t *elfFile, size_t ph);
+uintptr_t elf_getProgramHeaderVaddr(const elf_t *elfFile, size_t ph);
 
 /**
  * Return the base physical address of given program header.
@@ -357,7 +357,7 @@ uintptr_t elf_getProgramHeaderVaddr(elf_t *elfFile, size_t ph);
  *
  * \return The memory size of the specified program header.
  */
-uintptr_t elf_getProgramHeaderPaddr(elf_t *elfFile, size_t ph);
+uintptr_t elf_getProgramHeaderPaddr(const elf_t *elfFile, size_t ph);
 
 /**
  * Return the file size of a given program header.
@@ -367,7 +367,7 @@ uintptr_t elf_getProgramHeaderPaddr(elf_t *elfFile, size_t ph);
  *
  * \return The file size of the specified program header.
  */
-size_t elf_getProgramHeaderFileSize(elf_t *elfFile, size_t ph);
+size_t elf_getProgramHeaderFileSize(const elf_t *elfFile, size_t ph);
 
 /**
  * Return the memory size of a given program header.
@@ -377,7 +377,7 @@ size_t elf_getProgramHeaderFileSize(elf_t *elfFile, size_t ph);
  *
  * \return The memory size of the specified program header.
  */
-size_t elf_getProgramHeaderMemorySize(elf_t *elfFile, size_t ph);
+size_t elf_getProgramHeaderMemorySize(const elf_t *elfFile, size_t ph);
 
 /**
  * Return the flags for a given program header.
@@ -387,7 +387,7 @@ size_t elf_getProgramHeaderMemorySize(elf_t *elfFile, size_t ph);
  *
  * \return The flags of a given program header.
  */
-uint32_t elf_getProgramHeaderFlags(elf_t *elfFile, size_t ph);
+uint32_t elf_getProgramHeaderFlags(const elf_t *elfFile, size_t ph);
 
 /**
  * Return the alignment for a given program header.
@@ -397,7 +397,7 @@ uint32_t elf_getProgramHeaderFlags(elf_t *elfFile, size_t ph);
  *
  * \return The alignment of the given program header.
  */
-size_t elf_getProgramHeaderAlign(elf_t *elfFile, size_t ph);
+size_t elf_getProgramHeaderAlign(const elf_t *elfFile, size_t ph);
 
 
 /* Utility functions */
@@ -413,20 +413,20 @@ size_t elf_getProgramHeaderAlign(elf_t *elfFile, size_t ph);
  *
  * \return true on success. false on failure, if for example, it is an invalid ELF file
  */
-int elf_getMemoryBounds(elf_t *elfFile, elf_addr_type_t addr_type, uintptr_t *min, uintptr_t *max);
+int elf_getMemoryBounds(const elf_t *elfFile, elf_addr_type_t addr_type, uintptr_t *min, uintptr_t *max);
 
 /**
  *
  * \return true if the address in in this program header
  */
-int elf_vaddrInProgramHeader(elf_t *elfFile, size_t ph, uintptr_t vaddr);
+int elf_vaddrInProgramHeader(const elf_t *elfFile, size_t ph, uintptr_t vaddr);
 
 /**
  * Return the physical translation of a physical address, with respect
  * to a given program header
  *
  */
-uintptr_t elf_vtopProgramHeader(elf_t *elfFile, size_t ph, uintptr_t vaddr);
+uintptr_t elf_vtopProgramHeader(const elf_t *elfFile, size_t ph, uintptr_t vaddr);
 
 /**
  * Load an ELF file into memory
@@ -446,4 +446,4 @@ uintptr_t elf_vtopProgramHeader(elf_t *elfFile, size_t ph, uintptr_t vaddr);
  * platform, we assume that any memory addresses are within the first 4GB.
  *
  */
-int elf_loadFile(elf_t *elfFile, elf_addr_type_t addr_type);
+int elf_loadFile(const elf_t *elfFile, elf_addr_type_t addr_type);

--- a/libelf/include/elf/elf32.h
+++ b/libelf/include/elf/elf32.h
@@ -12,140 +12,140 @@
 /* ELF header functions */
 int elf32_checkFile(elf_t *elf);
 
-int elf32_checkProgramHeaderTable(elf_t *elf);
+int elf32_checkProgramHeaderTable(const elf_t *elf);
 
-int elf32_checkSectionTable(elf_t *elf);
+int elf32_checkSectionTable(const elf_t *elf);
 
-static inline bool elf_isElf32(elf_t *elf)
+static inline bool elf_isElf32(const elf_t *elf)
 {
     return elf->elfClass == ELFCLASS32;
 }
 
-static inline Elf32_Ehdr elf32_getHeader(elf_t *elf)
+static inline Elf32_Ehdr elf32_getHeader(const elf_t *elf)
 {
     return *(Elf32_Ehdr *) elf->elfFile;
 }
 
-static inline uintptr_t elf32_getEntryPoint(elf_t *elf)
+static inline uintptr_t elf32_getEntryPoint(const elf_t *elf)
 {
     return elf32_getHeader(elf).e_entry;
 }
 
-static inline Elf32_Phdr *elf32_getProgramHeaderTable(elf_t *file)
+static inline const Elf32_Phdr *elf32_getProgramHeaderTable(const elf_t *file)
 {
     return file->elfFile + elf32_getHeader(file).e_phoff;
 }
 
-static inline Elf32_Shdr *elf32_getSectionTable(elf_t *elf)
+static inline const Elf32_Shdr *elf32_getSectionTable(const elf_t *elf)
 {
     return elf->elfFile + elf32_getHeader(elf).e_shoff;
 }
 
-static inline size_t elf32_getNumProgramHeaders(elf_t *elf)
+static inline size_t elf32_getNumProgramHeaders(const elf_t *elf)
 {
     return elf32_getHeader(elf).e_phnum;
 }
 
-static inline size_t elf32_getNumSections(elf_t *elf)
+static inline size_t elf32_getNumSections(const elf_t *elf)
 {
     return elf32_getHeader(elf).e_shnum;
 }
 
-static inline size_t elf32_getSectionStringTableIndex(elf_t *elf)
+static inline size_t elf32_getSectionStringTableIndex(const elf_t *elf)
 {
     return elf32_getHeader(elf).e_shstrndx;
 }
 
 
 /* Section header functions */
-static inline size_t elf32_getSectionNameOffset(elf_t *elf, size_t s)
+static inline size_t elf32_getSectionNameOffset(const elf_t *elf, size_t s)
 {
     return elf32_getSectionTable(elf)[s].sh_name;
 }
 
-static inline uint32_t elf32_getSectionType(elf_t *elf, size_t i)
+static inline uint32_t elf32_getSectionType(const elf_t *elf, size_t i)
 {
     return elf32_getSectionTable(elf)[i].sh_type;
 }
 
-static inline size_t elf32_getSectionFlags(elf_t *elf, size_t i)
+static inline size_t elf32_getSectionFlags(const elf_t *elf, size_t i)
 {
     return elf32_getSectionTable(elf)[i].sh_flags;
 }
 
-static inline uintptr_t elf32_getSectionAddr(elf_t *elf, size_t i)
+static inline uintptr_t elf32_getSectionAddr(const elf_t *elf, size_t i)
 {
     return elf32_getSectionTable(elf)[i].sh_addr;
 }
 
-static inline size_t elf32_getSectionOffset(elf_t *elf, size_t i)
+static inline size_t elf32_getSectionOffset(const elf_t *elf, size_t i)
 {
     return elf32_getSectionTable(elf)[i].sh_offset;
 }
 
-static inline size_t elf32_getSectionSize(elf_t *elf, size_t i)
+static inline size_t elf32_getSectionSize(const elf_t *elf, size_t i)
 {
     return elf32_getSectionTable(elf)[i].sh_size;
 }
 
-static inline uint32_t elf32_getSectionLink(elf_t *elf, size_t i)
+static inline uint32_t elf32_getSectionLink(const elf_t *elf, size_t i)
 {
     return elf32_getSectionTable(elf)[i].sh_link;
 }
 
-static inline uint32_t elf32_getSectionInfo(elf_t *elf, size_t i)
+static inline uint32_t elf32_getSectionInfo(const elf_t *elf, size_t i)
 {
     return elf32_getSectionTable(elf)[i].sh_info;
 }
 
-static inline size_t elf32_getSectionAddrAlign(elf_t *elf, size_t i)
+static inline size_t elf32_getSectionAddrAlign(const elf_t *elf, size_t i)
 {
     return elf32_getSectionTable(elf)[i].sh_addralign;
 }
 
-static inline size_t elf32_getSectionEntrySize(elf_t *elf, size_t i)
+static inline size_t elf32_getSectionEntrySize(const elf_t *elf, size_t i)
 {
     return elf32_getSectionTable(elf)[i].sh_entsize;
 }
 
 
 /* Program header functions */
-static inline uint32_t elf32_getProgramHeaderType(elf_t *file, size_t ph)
+static inline uint32_t elf32_getProgramHeaderType(const elf_t *file, size_t ph)
 {
     return elf32_getProgramHeaderTable(file)[ph].p_type;
 }
 
-static inline size_t elf32_getProgramHeaderOffset(elf_t *file, size_t ph)
+static inline size_t elf32_getProgramHeaderOffset(const elf_t *file, size_t ph)
 {
     return elf32_getProgramHeaderTable(file)[ph].p_offset;
 }
 
-static inline uintptr_t elf32_getProgramHeaderVaddr(elf_t *file, size_t ph)
+static inline uintptr_t elf32_getProgramHeaderVaddr(const elf_t *file, size_t ph)
 {
     return elf32_getProgramHeaderTable(file)[ph].p_vaddr;
 }
 
-static inline uintptr_t elf32_getProgramHeaderPaddr(elf_t *file, size_t ph)
+static inline uintptr_t elf32_getProgramHeaderPaddr(const elf_t *file, size_t ph)
 {
     return elf32_getProgramHeaderTable(file)[ph].p_paddr;
 }
 
-static inline size_t elf32_getProgramHeaderFileSize(elf_t *file, size_t ph)
+static inline size_t elf32_getProgramHeaderFileSize(const elf_t *file, size_t ph)
 {
     return elf32_getProgramHeaderTable(file)[ph].p_filesz;
 }
 
-static inline size_t elf32_getProgramHeaderMemorySize(elf_t *file, size_t ph)
+static inline size_t elf32_getProgramHeaderMemorySize(const elf_t *file, size_t ph)
 {
     return elf32_getProgramHeaderTable(file)[ph].p_memsz;
 }
 
-static inline uint32_t elf32_getProgramHeaderFlags(elf_t *file, size_t ph)
+static inline uint32_t elf32_getProgramHeaderFlags(const elf_t *file, size_t ph)
 {
     return elf32_getProgramHeaderTable(file)[ph].p_flags;
 }
 
-static inline size_t elf32_getProgramHeaderAlign(elf_t *file, size_t ph)
+static inline size_t elf32_getProgramHeaderAlign(const elf_t *file, size_t ph)
 {
     return elf32_getProgramHeaderTable(file)[ph].p_align;
 }

--- a/libelf/include/elf/elf64.h
+++ b/libelf/include/elf/elf64.h
@@ -12,140 +12,140 @@
 /* ELF header functions */
 int elf64_checkFile(elf_t *elf);
 
-int elf64_checkProgramHeaderTable(elf_t *elf);
+int elf64_checkProgramHeaderTable(const elf_t *elf);
 
-int elf64_checkSectionTable(elf_t *elf);
+int elf64_checkSectionTable(const elf_t *elf);
 
-static inline bool elf_isElf64(elf_t *elf)
+static inline bool elf_isElf64(const elf_t *elf)
 {
     return elf->elfClass == ELFCLASS64;
 }
 
-static inline Elf64_Ehdr elf64_getHeader(elf_t *elf)
+static inline Elf64_Ehdr elf64_getHeader(const elf_t *elf)
 {
     return *(Elf64_Ehdr *) elf->elfFile;
 }
 
-static inline uintptr_t elf64_getEntryPoint(elf_t *file)
+static inline uintptr_t elf64_getEntryPoint(const elf_t *file)
 {
     return elf64_getHeader(file).e_entry;
 }
 
-static inline Elf64_Phdr *elf64_getProgramHeaderTable(elf_t *file)
+static inline const Elf64_Phdr *elf64_getProgramHeaderTable(const elf_t *file)
 {
     return file->elfFile + elf64_getHeader(file).e_phoff;
 }
 
-static inline Elf64_Shdr *elf64_getSectionTable(elf_t *file)
+static inline const Elf64_Shdr *elf64_getSectionTable(const elf_t *file)
 {
     return file->elfFile + elf64_getHeader(file).e_shoff;
 }
 
-static inline size_t elf64_getNumProgramHeaders(elf_t *file)
+static inline size_t elf64_getNumProgramHeaders(const elf_t *file)
 {
     return elf64_getHeader(file).e_phnum;
 }
 
-static inline size_t elf64_getNumSections(elf_t *elf)
+static inline size_t elf64_getNumSections(const elf_t *elf)
 {
     return elf64_getHeader(elf).e_shnum;
 }
 
-static inline size_t elf64_getSectionStringTableIndex(elf_t *elf)
+static inline size_t elf64_getSectionStringTableIndex(const elf_t *elf)
 {
     return elf64_getHeader(elf).e_shstrndx;
 }
 
 
 /* Section header functions */
-static inline size_t elf64_getSectionNameOffset(elf_t *elf, size_t s)
+static inline size_t elf64_getSectionNameOffset(const elf_t *elf, size_t s)
 {
     return elf64_getSectionTable(elf)[s].sh_name;
 }
 
-static inline uint32_t elf64_getSectionType(elf_t *file, size_t s)
+static inline uint32_t elf64_getSectionType(const elf_t *file, size_t s)
 {
     return elf64_getSectionTable(file)[s].sh_type;
 }
 
-static inline size_t elf64_getSectionFlags(elf_t *file, size_t s)
+static inline size_t elf64_getSectionFlags(const elf_t *file, size_t s)
 {
     return elf64_getSectionTable(file)[s].sh_flags;
 }
 
-static inline uintptr_t elf64_getSectionAddr(elf_t *elf, size_t i)
+static inline uintptr_t elf64_getSectionAddr(const elf_t *elf, size_t i)
 {
     return elf64_getSectionTable(elf)[i].sh_addr;
 }
 
-static inline size_t elf64_getSectionOffset(elf_t *elf, size_t i)
+static inline size_t elf64_getSectionOffset(const elf_t *elf, size_t i)
 {
     return elf64_getSectionTable(elf)[i].sh_offset;
 }
 
-static inline size_t elf64_getSectionSize(elf_t *elf, size_t i)
+static inline size_t elf64_getSectionSize(const elf_t *elf, size_t i)
 {
     return elf64_getSectionTable(elf)[i].sh_size;
 }
 
-static inline uint32_t elf64_getSectionLink(elf_t *elf, size_t i)
+static inline uint32_t elf64_getSectionLink(const elf_t *elf, size_t i)
 {
     return elf64_getSectionTable(elf)[i].sh_link;
 }
 
-static inline uint32_t elf64_getSectionInfo(elf_t *elf, size_t i)
+static inline uint32_t elf64_getSectionInfo(const elf_t *elf, size_t i)
 {
     return elf64_getSectionTable(elf)[i].sh_info;
 }
 
-static inline size_t elf64_getSectionAddrAlign(elf_t *elf, size_t i)
+static inline size_t elf64_getSectionAddrAlign(const elf_t *elf, size_t i)
 {
     return elf64_getSectionTable(elf)[i].sh_addralign;
 }
 
-static inline size_t elf64_getSectionEntrySize(elf_t *elf, size_t i)
+static inline size_t elf64_getSectionEntrySize(const elf_t *elf, size_t i)
 {
     return elf64_getSectionTable(elf)[i].sh_entsize;
 }
 
 
 /* Program header functions */
-static inline uint32_t elf64_getProgramHeaderType(elf_t *file, size_t ph)
+static inline uint32_t elf64_getProgramHeaderType(const elf_t *file, size_t ph)
 {
     return elf64_getProgramHeaderTable(file)[ph].p_type;
 }
 
-static inline size_t elf64_getProgramHeaderOffset(elf_t *file, size_t ph)
+static inline size_t elf64_getProgramHeaderOffset(const elf_t *file, size_t ph)
 {
     return elf64_getProgramHeaderTable(file)[ph].p_offset;
 }
 
-static inline uintptr_t elf64_getProgramHeaderVaddr(elf_t *file, size_t ph)
+static inline uintptr_t elf64_getProgramHeaderVaddr(const elf_t *file, size_t ph)
 {
     return elf64_getProgramHeaderTable(file)[ph].p_vaddr;
 }
 
-static inline uintptr_t elf64_getProgramHeaderPaddr(elf_t *file, size_t ph)
+static inline uintptr_t elf64_getProgramHeaderPaddr(const elf_t *file, size_t ph)
 {
     return elf64_getProgramHeaderTable(file)[ph].p_paddr;
 }
 
-static inline size_t elf64_getProgramHeaderFileSize(elf_t *file, size_t ph)
+static inline size_t elf64_getProgramHeaderFileSize(const elf_t *file, size_t ph)
 {
     return elf64_getProgramHeaderTable(file)[ph].p_filesz;
 }
 
-static inline size_t elf64_getProgramHeaderMemorySize(elf_t *file, size_t ph)
+static inline size_t elf64_getProgramHeaderMemorySize(const elf_t *file, size_t ph)
 {
     return elf64_getProgramHeaderTable(file)[ph].p_memsz;
 }
 
-static inline uint32_t elf64_getProgramHeaderFlags(elf_t *file, size_t ph)
+static inline uint32_t elf64_getProgramHeaderFlags(const elf_t *file, size_t ph)
 {
     return elf64_getProgramHeaderTable(file)[ph].p_flags;
 }
 
-static inline size_t elf64_getProgramHeaderAlign(elf_t *file, size_t ph)
+static inline size_t elf64_getProgramHeaderAlign(const elf_t *file, size_t ph)
 {
     return elf64_getProgramHeaderTable(file)[ph].p_align;
 }

--- a/libelf/src/elf.c
+++ b/libelf/src/elf.c
@@ -11,12 +11,12 @@
 #include <stdio.h>
 
 /* ELF header functions */
-int elf_newFile(void *file, size_t size, elf_t *res)
+int elf_newFile(const void *file, size_t size, elf_t *res)
 {
     return elf_newFile_maybe_unsafe(file, size, true, true, res);
 }
 
-int elf_newFile_maybe_unsafe(void *file, size_t size, bool check_pht, bool check_st, elf_t *res)
+int elf_newFile_maybe_unsafe(const void *file, size_t size, bool check_pht, bool check_st, elf_t *res)
 {
     elf_t new_file = {
         .elfFile = file,
@@ -49,7 +49,7 @@ int elf_newFile_maybe_unsafe(void *file, size_t size, bool check_pht, bool check
     return status;
 }
 
-int elf_check_magic(char *file)
+int elf_check_magic(const char *file)
 {
     if (memcmp(file, ELFMAG, SELFMAG) != 0) {
         return -1;
@@ -77,7 +77,7 @@ int elf_checkFile(elf_t *elfFile)
     return -1;
 }
 
-int elf_checkProgramHeaderTable(elf_t *elfFile)
+int elf_checkProgramHeaderTable(const elf_t *elfFile)
 {
     if (elf_isElf32(elfFile)) {
         return elf32_checkProgramHeaderTable(elfFile);
@@ -86,7 +86,7 @@ int elf_checkProgramHeaderTable(elf_t *elfFile)
     }
 }
 
-int elf_checkSectionTable(elf_t *elfFile)
+int elf_checkSectionTable(const elf_t *elfFile)
 {
     if (elf_isElf32(elfFile)) {
         return elf32_checkSectionTable(elfFile);
@@ -95,7 +95,7 @@ int elf_checkSectionTable(elf_t *elfFile)
     }
 }
 
-uintptr_t elf_getEntryPoint(elf_t *elfFile)
+uintptr_t elf_getEntryPoint(const elf_t *elfFile)
 {
     if (elf_isElf32(elfFile)) {
         return elf32_getEntryPoint(elfFile);
@@ -104,7 +104,7 @@ uintptr_t elf_getEntryPoint(elf_t *elfFile)
     }
 }
 
-size_t elf_getNumProgramHeaders(elf_t *elfFile)
+size_t elf_getNumProgramHeaders(const elf_t *elfFile)
 {
     if (elf_isElf32(elfFile)) {
         return elf32_getNumProgramHeaders(elfFile);
@@ -113,7 +113,7 @@ size_t elf_getNumProgramHeaders(elf_t *elfFile)
     }
 }
 
-size_t elf_getNumSections(elf_t *elfFile)
+size_t elf_getNumSections(const elf_t *elfFile)
 {
     if (elf_isElf32(elfFile)) {
         return elf32_getNumSections(elfFile);
@@ -122,7 +122,7 @@ size_t elf_getNumSections(elf_t *elfFile)
     }
 }
 
-size_t elf_getSectionStringTableIndex(elf_t *elf)
+size_t elf_getSectionStringTableIndex(const elf_t *elf)
 {
     if (elf_isElf32(elf)) {
         return elf32_getSectionStringTableIndex(elf);
@@ -131,7 +131,7 @@ size_t elf_getSectionStringTableIndex(elf_t *elf)
     }
 }
 
-const char *elf_getStringTable(elf_t *elf, size_t string_segment)
+const char *elf_getStringTable(const elf_t *elf, size_t string_segment)
 {
     const char *string_table = elf_getSection(elf, string_segment);
     if (string_table == NULL) {
@@ -150,7 +150,7 @@ const char *elf_getStringTable(elf_t *elf, size_t string_segment)
     return string_table;
 }
 
-const char *elf_getSectionStringTable(elf_t *elf)
+const char *elf_getSectionStringTable(const elf_t *elf)
 {
     size_t index = elf_getSectionStringTableIndex(elf);
     return elf_getStringTable(elf, index);
@@ -158,7 +158,7 @@ const char *elf_getSectionStringTable(elf_t *elf)
 
 
 /* Section header functions */
-void *elf_getSection(elf_t *elf, size_t i)
+const void *elf_getSection(const elf_t *elf, size_t i)
 {
     if (i == 0 || i >= elf_getNumSections(elf)) {
         return NULL; /* no such section */
@@ -179,7 +179,7 @@ void *elf_getSection(elf_t *elf, size_t i)
     return elf->elfFile + section_offset;
 }
 
-void *elf_getSectionNamed(elf_t *elfFile, const char *str, size_t *id)
+const void *elf_getSectionNamed(const elf_t *elfFile, const char *str, size_t *id)
 {
     size_t numSections = elf_getNumSections(elfFile);
     for (size_t i = 0; i < numSections; i++) {
@@ -193,7 +193,7 @@ void *elf_getSectionNamed(elf_t *elfFile, const char *str, size_t *id)
     return NULL;
 }
 
-const char *elf_getSectionName(elf_t *elf, size_t i)
+const char *elf_getSectionName(const elf_t *elf, size_t i)
 {
     size_t str_table_idx = elf_getSectionStringTableIndex(elf);
     const char *str_table = elf_getStringTable(elf, str_table_idx);
@@ -207,7 +207,7 @@ const char *elf_getSectionName(elf_t *elf, size_t i)
     return str_table + offset;
 }
 
-size_t elf_getSectionNameOffset(elf_t *elfFile, size_t i)
+size_t elf_getSectionNameOffset(const elf_t *elfFile, size_t i)
 {
     if (elf_isElf32(elfFile)) {
         return elf32_getSectionNameOffset(elfFile, i);
@@ -216,7 +216,7 @@ size_t elf_getSectionNameOffset(elf_t *elfFile, size_t i)
     }
 }
 
-uint32_t elf_getSectionType(elf_t *elfFile, size_t i)
+uint32_t elf_getSectionType(const elf_t *elfFile, size_t i)
 {
     if (elf_isElf32(elfFile)) {
         return elf32_getSectionType(elfFile, i);
@@ -225,7 +225,7 @@ uint32_t elf_getSectionType(elf_t *elfFile, size_t i)
     }
 }
 
-size_t elf_getSectionFlags(elf_t *elfFile, size_t i)
+size_t elf_getSectionFlags(const elf_t *elfFile, size_t i)
 {
     if (elf_isElf32(elfFile)) {
         return elf32_getSectionFlags(elfFile, i);
@@ -234,7 +234,7 @@ size_t elf_getSectionFlags(elf_t *elfFile, size_t i)
     }
 }
 
-uintptr_t elf_getSectionAddr(elf_t *elfFile, size_t i)
+uintptr_t elf_getSectionAddr(const elf_t *elfFile, size_t i)
 {
     if (elf_isElf32(elfFile)) {
         return elf32_getSectionAddr(elfFile, i);
@@ -243,7 +243,7 @@ uintptr_t elf_getSectionAddr(elf_t *elfFile, size_t i)
     }
 }
 
-size_t elf_getSectionOffset(elf_t *elfFile, size_t i)
+size_t elf_getSectionOffset(const elf_t *elfFile, size_t i)
 {
     if (elf_isElf32(elfFile)) {
         return elf32_getSectionOffset(elfFile, i);
@@ -252,7 +252,7 @@ size_t elf_getSectionOffset(elf_t *elfFile, size_t i)
     }
 }
 
-size_t elf_getSectionSize(elf_t *elfFile, size_t i)
+size_t elf_getSectionSize(const elf_t *elfFile, size_t i)
 {
     if (elf_isElf32(elfFile)) {
         return elf32_getSectionSize(elfFile, i);
@@ -261,7 +261,7 @@ size_t elf_getSectionSize(elf_t *elfFile, size_t i)
     }
 }
 
-uint32_t elf_getSectionLink(elf_t *elfFile, size_t i)
+uint32_t elf_getSectionLink(const elf_t *elfFile, size_t i)
 {
     if (elf_isElf32(elfFile)) {
         return elf32_getSectionLink(elfFile, i);
@@ -270,7 +270,7 @@ uint32_t elf_getSectionLink(elf_t *elfFile, size_t i)
     }
 }
 
-uint32_t elf_getSectionInfo(elf_t *elfFile, size_t i)
+uint32_t elf_getSectionInfo(const elf_t *elfFile, size_t i)
 {
     if (elf_isElf32(elfFile)) {
         return elf32_getSectionInfo(elfFile, i);
@@ -279,7 +279,7 @@ uint32_t elf_getSectionInfo(elf_t *elfFile, size_t i)
     }
 }
 
-size_t elf_getSectionAddrAlign(elf_t *elfFile, size_t i)
+size_t elf_getSectionAddrAlign(const elf_t *elfFile, size_t i)
 {
     if (elf_isElf32(elfFile)) {
         return elf32_getSectionAddrAlign(elfFile, i);
@@ -288,7 +288,7 @@ size_t elf_getSectionAddrAlign(elf_t *elfFile, size_t i)
     }
 }
 
-size_t elf_getSectionEntrySize(elf_t *elfFile, size_t i)
+size_t elf_getSectionEntrySize(const elf_t *elfFile, size_t i)
 {
     if (elf_isElf32(elfFile)) {
         return elf32_getSectionEntrySize(elfFile, i);
@@ -299,7 +299,7 @@ size_t elf_getSectionEntrySize(elf_t *elfFile, size_t i)
 
 
 /* Program headers function */
-void *elf_getProgramSegment(elf_t *elf, size_t ph)
+const void *elf_getProgramSegment(const elf_t *elf, size_t ph)
 {
     size_t offset = elf_getProgramHeaderOffset(elf, ph);
     size_t file_size = elf_getProgramHeaderFileSize(elf, ph);
@@ -312,7 +312,7 @@ void *elf_getProgramSegment(elf_t *elf, size_t ph)
     return elf->elfFile + offset;
 }
 
-uint32_t elf_getProgramHeaderType(elf_t *elfFile, size_t ph)
+uint32_t elf_getProgramHeaderType(const elf_t *elfFile, size_t ph)
 {
     if (elf_isElf32(elfFile)) {
         return elf32_getProgramHeaderType(elfFile, ph);
@@ -321,7 +321,7 @@ uint32_t elf_getProgramHeaderType(elf_t *elfFile, size_t ph)
     }
 }
 
-size_t elf_getProgramHeaderOffset(elf_t *elfFile, size_t ph)
+size_t elf_getProgramHeaderOffset(const elf_t *elfFile, size_t ph)
 {
     if (elf_isElf32(elfFile)) {
         return elf32_getProgramHeaderOffset(elfFile, ph);
@@ -330,7 +330,7 @@ size_t elf_getProgramHeaderOffset(elf_t *elfFile, size_t ph)
     }
 }
 
-uintptr_t elf_getProgramHeaderVaddr(elf_t *elfFile, size_t ph)
+uintptr_t elf_getProgramHeaderVaddr(const elf_t *elfFile, size_t ph)
 {
     if (elf_isElf32(elfFile)) {
         return elf32_getProgramHeaderVaddr(elfFile, ph);
@@ -339,7 +339,7 @@ uintptr_t elf_getProgramHeaderVaddr(elf_t *elfFile, size_t ph)
     }
 }
 
-uintptr_t elf_getProgramHeaderPaddr(elf_t *elfFile, size_t ph)
+uintptr_t elf_getProgramHeaderPaddr(const elf_t *elfFile, size_t ph)
 {
     if (elf_isElf32(elfFile)) {
         return elf32_getProgramHeaderPaddr(elfFile, ph);
@@ -348,7 +348,7 @@ uintptr_t elf_getProgramHeaderPaddr(elf_t *elfFile, size_t ph)
     }
 }
 
-size_t elf_getProgramHeaderFileSize(elf_t *elfFile, size_t ph)
+size_t elf_getProgramHeaderFileSize(const elf_t *elfFile, size_t ph)
 {
     if (elf_isElf32(elfFile)) {
         return elf32_getProgramHeaderFileSize(elfFile, ph);
@@ -357,7 +357,7 @@ size_t elf_getProgramHeaderFileSize(elf_t *elfFile, size_t ph)
     }
 }
 
-size_t elf_getProgramHeaderMemorySize(elf_t *elfFile, size_t ph)
+size_t elf_getProgramHeaderMemorySize(const elf_t *elfFile, size_t ph)
 {
     if (elf_isElf32(elfFile)) {
         return elf32_getProgramHeaderMemorySize(elfFile, ph);
@@ -366,7 +366,7 @@ size_t elf_getProgramHeaderMemorySize(elf_t *elfFile, size_t ph)
     }
 }
 
-uint32_t elf_getProgramHeaderFlags(elf_t *elfFile, size_t ph)
+uint32_t elf_getProgramHeaderFlags(const elf_t *elfFile, size_t ph)
 {
     if (elf_isElf32(elfFile)) {
         return elf32_getProgramHeaderFlags(elfFile, ph);
@@ -375,7 +375,7 @@ uint32_t elf_getProgramHeaderFlags(elf_t *elfFile, size_t ph)
     }
 }
 
-size_t elf_getProgramHeaderAlign(elf_t *elfFile, size_t ph)
+size_t elf_getProgramHeaderAlign(const elf_t *elfFile, size_t ph)
 {
     if (elf_isElf32(elfFile)) {
         return elf32_getProgramHeaderAlign(elfFile, ph);
@@ -386,7 +386,7 @@ size_t elf_getProgramHeaderAlign(elf_t *elfFile, size_t ph)
 
 
 /* Utility functions */
-int elf_getMemoryBounds(elf_t *elfFile, elf_addr_type_t addr_type, uintptr_t *min, uintptr_t *max)
+int elf_getMemoryBounds(const elf_t *elfFile, elf_addr_type_t addr_type, uintptr_t *min, uintptr_t *max)
 {
     uintptr_t mem_min = UINTPTR_MAX;
     uintptr_t mem_max = 0;
@@ -420,7 +420,7 @@ int elf_getMemoryBounds(elf_t *elfFile, elf_addr_type_t addr_type, uintptr_t *mi
     return 1;
 }
 
-int elf_vaddrInProgramHeader(elf_t *elfFile, size_t ph, uintptr_t vaddr)
+int elf_vaddrInProgramHeader(const elf_t *elfFile, size_t ph, uintptr_t vaddr)
 {
     uintptr_t min = elf_getProgramHeaderVaddr(elfFile, ph);
     uintptr_t max = min + elf_getProgramHeaderMemorySize(elfFile, ph);
@@ -431,7 +431,7 @@ int elf_vaddrInProgramHeader(elf_t *elfFile, size_t ph, uintptr_t vaddr)
     }
 }
 
-uintptr_t elf_vtopProgramHeader(elf_t *elfFile, size_t ph, uintptr_t vaddr)
+uintptr_t elf_vtopProgramHeader(const elf_t *elfFile, size_t ph, uintptr_t vaddr)
 {
     uintptr_t ph_phys = elf_getProgramHeaderPaddr(elfFile, ph);
     uintptr_t ph_virt = elf_getProgramHeaderVaddr(elfFile, ph);
@@ -442,7 +442,7 @@ uintptr_t elf_vtopProgramHeader(elf_t *elfFile, size_t ph, uintptr_t vaddr)
     return paddr;
 }
 
-int elf_loadFile(elf_t *elf, elf_addr_type_t addr_type)
+int elf_loadFile(const elf_t *elf, elf_addr_type_t addr_type)
 {
     size_t i;
 

--- a/libelf/src/elf32.c
+++ b/libelf/src/elf32.c
@@ -20,7 +20,7 @@ int elf32_checkFile(elf_t *elf)
         return -1; /* not an ELF file */
     }
 
-    Elf32_Ehdr *header = elf->elfFile;
+    Elf32_Ehdr const *header = elf->elfFile;
     if (header->e_ident[EI_CLASS] != ELFCLASS32) {
         return -1; /* not a 32-bit ELF */
     }
@@ -41,9 +41,9 @@ int elf32_checkFile(elf_t *elf)
     return 0; /* elf header looks OK */
 }
 
-int elf32_checkProgramHeaderTable(elf_t *elf)
+int elf32_checkProgramHeaderTable(const elf_t *elf)
 {
-    Elf32_Ehdr *header = elf->elfFile;
+    const Elf32_Ehdr *header = elf->elfFile;
     size_t ph_end = header->e_phoff + header->e_phentsize * header->e_phnum;
     if (elf->elfSize < ph_end || ph_end < header->e_phoff) {
         return -1; /* invalid program header table */
@@ -52,9 +52,9 @@ int elf32_checkProgramHeaderTable(elf_t *elf)
     return 0;
 }
 
-int elf32_checkSectionTable(elf_t *elf)
+int elf32_checkSectionTable(const elf_t *elf)
 {
-    Elf32_Ehdr *header = elf->elfFile;
+    const Elf32_Ehdr *header = elf->elfFile;
     size_t sh_end = header->e_shoff + header->e_shentsize * header->e_shnum;
     if (elf->elfSize < sh_end || sh_end < header->e_shoff) {
         return -1; /* invalid section header table */

--- a/libelf/src/elf64.c
+++ b/libelf/src/elf64.c
@@ -24,7 +24,7 @@ int elf64_checkFile(elf_t *elf)
         return -1; /* not an ELF file */
     }
 
-    Elf64_Ehdr *header = elf->elfFile;
+    Elf64_Ehdr const *header = elf->elfFile;
     if (header->e_ident[EI_CLASS] != ELFCLASS64) {
         return -1; /* not a 64-bit ELF */
     }
@@ -45,9 +45,9 @@ int elf64_checkFile(elf_t *elf)
     return 0; /* elf header looks OK */
 }
 
-int elf64_checkProgramHeaderTable(elf_t *elf)
+int elf64_checkProgramHeaderTable(const elf_t *elf)
 {
-    Elf64_Ehdr *header = elf->elfFile;
+    const Elf64_Ehdr *header = elf->elfFile;
     size_t ph_end = header->e_phoff + header->e_phentsize * header->e_phnum;
     if (elf->elfSize < ph_end || ph_end < header->e_phoff) {
         return -1; /* invalid program header table */
@@ -56,9 +56,9 @@ int elf64_checkProgramHeaderTable(elf_t *elf)
     return 0;
 }
 
-int elf64_checkSectionTable(elf_t *elf)
+int elf64_checkSectionTable(const elf_t *elf)
 {
-    Elf64_Ehdr *header = elf->elfFile;
+    const Elf64_Ehdr *header = elf->elfFile;
     size_t sh_end = header->e_shoff + header->e_shentsize * header->e_shnum;
     if (elf->elfSize < sh_end || sh_end < header->e_shoff) {
         return -1; /* invalid section header table */


### PR DESCRIPTION
CPIO is handling fixed data, so it should use the `const` qualifier wherever possible. This allows passing it const data and use the type checking features from the compiler to find invalid usages. 

Note that this change will break the ElfLoader (at least in strict mode), as it does not use const either. There is a commit in https://github.com/seL4/seL4_tools/pull/54 that fixed this.