### PR TITLE
trivial: Remove compiler warning for imx8m clock

### DIFF
--- a/libplatsupport/src/plat/imx8m/clock.c
+++ b/libplatsupport/src/plat/imx8m/clock.c
@@ -5,5 +5,5 @@
  */
 #include <platsupport/clock.h>
 
-clk_t *ps_clocks[];
-freq_t ps_freq_default[];
+clk_t *ps_clocks[] = {};
+freq_t ps_freq_default[] = {};


### PR DESCRIPTION
Signed-off-by: Damon Lee <Damon.Lee@data61.csiro.au>