### PR TITLE
libplatsupport/imx6: add missing include

### DIFF
--- a/libethdrivers/src/plat/imx6/uboot/imx-regs.h
+++ b/libethdrivers/src/plat/imx6/uboot/imx-regs.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <autoconf.h>
 #include <stdint.h>
 
 #define ARCH_MXC


### PR DESCRIPTION
Fix https://github.com/seL4/util_libs/issues/86, commit taken from https://github.com/seL4/util_libs/pull/83