### PR TITLE
libplatsupport,imx6: Fix deref typo in arm clock

### DIFF
--- a/libplatsupport/src/plat/imx6/clock.c
+++ b/libplatsupport/src/plat/imx6/clock.c
@@ -245,7 +245,7 @@ static freq_t _arm_get_freq(clk_t *clk)
         return 0;
     }
 
-    uint32_t v = clk_regs.alg->pll_enet.val;
+    uint32_t v = clk_regs.alg->pll_arm.val;
 
     /* clock output enabled? */
     if (!(v & PLL_ENABLE)) {


### PR DESCRIPTION
There was a typo in the derefencing of the clock controllers registers
that fetched the wrong divisor for calculating the frequency of a clock.

Signed-off-by: Damon Lee <Damon.Lee@data61.csiro.au>