### PR TITLE
Add odroidc4 support

### DIFF
--- a/libplatsupport/plat_include/odroidc2/platsupport/plat/meson_timer.h
+++ b/libplatsupport/plat_include/odroidc2/platsupport/plat/meson_timer.h
@@ -7,11 +7,7 @@
 #pragma once
 
 #include <platsupport/timer.h>
-
-#define TIMER_BASE      0xc1100000
-#define TIMER_MAP_BASE  0xc1109000
-
-#define TIMER_REG_START   0x2650    // TIMER_MUX
+#include <platsupport/plat/odroid_timer.h>
 
 #define TIMER_E_INPUT_CLK 8
 #define TIMER_D_INPUT_CLK 6

--- a/libplatsupport/plat_include/odroidc2/platsupport/plat/odroid_serial.h
+++ b/libplatsupport/plat_include/odroidc2/platsupport/plat/odroid_serial.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#define UART0_PADDR     0xc1108000
+#define UART1_PADDR     0xc1108000
+#define UART2_PADDR     0xc1108000
+#define UART0_AO_PADDR  0xc8100000
+#define UART2_AO_PADDR  0xc8104000
+
+#define UART0_OFFSET    0x4c0
+#define UART1_OFFSET    0x4dc
+#define UART2_OFFSET    0x700
+#define UART0_AO_OFFSET 0x4c0
+#define UART2_AO_OFFSET 0x4e0
+
+#define UART0_IRQ       54
+#define UART1_IRQ       105
+#define UART2_IRQ       123
+#define UART0_AO_IRQ    225
+#define UART2_AO_IRQ    229
+

--- a/libplatsupport/plat_include/odroidc2/platsupport/plat/odroid_timer.h
+++ b/libplatsupport/plat_include/odroidc2/platsupport/plat/odroid_timer.h
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#define TIMER_BASE      0xc1100000
+#define TIMER_MAP_BASE  0xc1109000
+
+#define TIMER_REG_START   0x2650    // TIMER_MUX

--- a/libplatsupport/plat_include/odroidc2/platsupport/plat/serial.h
+++ b/libplatsupport/plat_include/odroidc2/platsupport/plat/serial.h
@@ -6,23 +6,7 @@
 
 #pragma once
 
-#define UART0_PADDR     0xc1108000
-#define UART1_PADDR     0xc1108000
-#define UART2_PADDR     0xc1108000
-#define UART0_AO_PADDR  0xc8100000
-#define UART2_AO_PADDR  0xc8104000
-
-#define UART0_OFFSET    0x4c0
-#define UART1_OFFSET    0x4dc
-#define UART2_OFFSET    0x700
-#define UART0_AO_OFFSET 0x4c0
-#define UART2_AO_OFFSET 0x4e0
-
-#define UART0_IRQ       54
-#define UART1_IRQ       105
-#define UART2_IRQ       123
-#define UART0_AO_IRQ    225
-#define UART2_AO_IRQ    229
+#include <platsupport/plat/odroid_serial.h>
 
 enum chardev_id {
     UART0,

--- a/libplatsupport/plat_include/odroidc4/platsupport/plat/clock.h
+++ b/libplatsupport/plat_include/odroidc4/platsupport/plat/clock.h
@@ -1,0 +1,1 @@
+../../../odroidc2/platsupport/plat/clock.h

--- a/libplatsupport/plat_include/odroidc4/platsupport/plat/i2c.h
+++ b/libplatsupport/plat_include/odroidc4/platsupport/plat/i2c.h
@@ -1,0 +1,1 @@
+../../../odroidc2/platsupport/plat/i2c.h

--- a/libplatsupport/plat_include/odroidc4/platsupport/plat/meson_timer.h
+++ b/libplatsupport/plat_include/odroidc4/platsupport/plat/meson_timer.h
@@ -1,0 +1,1 @@
+../../../odroidc2/platsupport/plat/meson_timer.h

--- a/libplatsupport/plat_include/odroidc4/platsupport/plat/odroid_serial.h
+++ b/libplatsupport/plat_include/odroidc4/platsupport/plat/odroid_serial.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#define UART0_PADDR     0xffd22000
+#define UART1_PADDR     0xffd24000
+#define UART2_PADDR     0xffd23000
+#define UART0_AO_PADDR  0xff803000
+#define UART2_AO_PADDR  0xff804000
+
+#define UART0_OFFSET    0x0
+#define UART1_OFFSET    0x0
+#define UART2_OFFSET    0x0
+#define UART0_AO_OFFSET 0x0
+#define UART2_AO_OFFSET 0x0
+
+#define UART0_IRQ       58
+#define UART1_IRQ       107
+#define UART2_IRQ       125
+#define UART0_AO_IRQ    225
+#define UART2_AO_IRQ    229

--- a/libplatsupport/plat_include/odroidc4/platsupport/plat/odroid_timer.h
+++ b/libplatsupport/plat_include/odroidc4/platsupport/plat/odroid_timer.h
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#define TIMER_BASE      0xffd00000
+#define TIMER_MAP_BASE  0xffd0f000
+
+#define TIMER_REG_START   0x3c50    // TIMER_MUX

--- a/libplatsupport/plat_include/odroidc4/platsupport/plat/serial.h
+++ b/libplatsupport/plat_include/odroidc4/platsupport/plat/serial.h
@@ -1,0 +1,1 @@
+../../../odroidc2/platsupport/plat/serial.h

--- a/libplatsupport/src/plat/odroidc4
+++ b/libplatsupport/src/plat/odroidc4
@@ -1,0 +1,1 @@
+odroidc2


### PR DESCRIPTION
This adds support for the ODroidC4. The ODroidC4 is just a beefier ODroidC2 with some bits moved around. The devices we care about here are all essentially the same.