### PR TITLE
Bcm2xxx extend mailbox

### DIFF
--- a/libplatsupport/plat_include/bcm2711/platsupport/plat/mailbox_util.h
+++ b/libplatsupport/plat_include/bcm2711/platsupport/plat/mailbox_util.h
@@ -41,12 +41,20 @@ enum {
     DEVICE_ID_CCP2TX
 };
 
-// Property Tags: https://github.com/raspberrypi/firmware/wiki/Mailbox-property-interface
+////////////////////////////////////////////////////////////////////////////////
+//--------------------------------Property Tags-------------------------------//
+////////////////////////////////////////////////////////////////////////////////
+
+// See: https://github.com/raspberrypi/firmware/wiki/Mailbox-property-interface
 #define TAG_SET_POWER_STATE     0x00028001
 #define TAG_GET_CLOCK_RATE      0x00030002
 #define TAG_GET_MAC_ADDRESS     0x00010003
 
 // TODO: Add more property tags if needed
+
+////////////////////////////////////////////////////////////////////////////////
+//-----------------------------Request/Reponse Tags---------------------------//
+////////////////////////////////////////////////////////////////////////////////
 
 // See: https://github.com/raspberrypi/firmware/wiki/Mailbox-property-interface#set-power-state
 #define SET_POWER_STATE_OFF             (0u << 0)
@@ -95,6 +103,10 @@ typedef struct {
 PropertyTag_GetMACAddress_Response_t;
 
 // TODO: Add more request/reponse tags if needed
+
+////////////////////////////////////////////////////////////////////////////////
+//-----------------------------Mailbox Functions------------------------------//
+////////////////////////////////////////////////////////////////////////////////
 
 bool bcm2711_set_power_state_on(mailbox_t *mbox, uint32_t device_id);
 

--- a/libplatsupport/plat_include/bcm2711/platsupport/plat/mailbox_util.h
+++ b/libplatsupport/plat_include/bcm2711/platsupport/plat/mailbox_util.h
@@ -52,7 +52,7 @@ enum {
 #define SET_POWER_STATE_OFF             (0u << 0)
 #define SET_POWER_STATE_ON              (1u << 0)
 #define SET_POWER_STATE_WAIT            (1u << 1)
-typedef struct PropertyTag_SetPowerState_Request {
+typedef struct {
     MailboxInterface_PropertyTag_t tag;
     uint32_t device_id;
     uint32_t state;
@@ -60,7 +60,7 @@ typedef struct PropertyTag_SetPowerState_Request {
 PropertyTag_SetPowerState_Request_t;
 
 #define SET_POWER_STATE_NO_DEVICE       (1u << 1)
-typedef struct PropertyTag_SetPowerState_Response {
+typedef struct {
     MailboxInterface_PropertyTag_t tag;
     uint32_t device_id;
     uint32_t state;
@@ -68,13 +68,13 @@ typedef struct PropertyTag_SetPowerState_Response {
 PropertyTag_SetPowerState_Response_t;
 
 // See: https://github.com/raspberrypi/firmware/wiki/Mailbox-property-interface#get-clock-rate
-typedef struct PropertyTag_GetClockRate_Request {
+typedef struct {
     MailboxInterface_PropertyTag_t tag;
     uint32_t clock_id;
 }
 PropertyTag_GetClockRate_Request_t;
 
-typedef struct PropertyTag_GetClockRate_Response {
+typedef struct {
     MailboxInterface_PropertyTag_t tag;
     uint32_t clock_id;
     uint32_t rate;
@@ -83,12 +83,12 @@ PropertyTag_GetClockRate_Response_t;
 
 // See: https://github.com/raspberrypi/firmware/wiki/Mailbox-property-interface#get-board-mac-address
 #define MAC_ADDRESS_SIZE 6
-typedef struct PropertyTag_GetMACAddress_Request {
+typedef struct {
     MailboxInterface_PropertyTag_t tag;
 }
 PropertyTag_GetMACAddress_Request_t;
 
-typedef struct PropertyTag_GetMACAddress_Response {
+typedef struct {
     MailboxInterface_PropertyTag_t tag;
     uint8_t mac_address[MAC_ADDRESS_SIZE];
 }

--- a/libplatsupport/plat_include/bcm2711/platsupport/plat/mailbox_util.h
+++ b/libplatsupport/plat_include/bcm2711/platsupport/plat/mailbox_util.h
@@ -44,6 +44,7 @@ enum {
 // Property Tags: https://github.com/raspberrypi/firmware/wiki/Mailbox-property-interface
 #define TAG_SET_POWER_STATE     0x00028001
 #define TAG_GET_CLOCK_RATE      0x00030002
+#define TAG_GET_MAC_ADDRESS     0x00010003
 
 // TODO: Add more property tags if needed
 
@@ -80,8 +81,25 @@ typedef struct PropertyTag_GetClockRate_Response {
 }
 PropertyTag_GetClockRate_Response_t;
 
+// See: https://github.com/raspberrypi/firmware/wiki/Mailbox-property-interface#get-board-mac-address
+#define MAC_ADDRESS_SIZE 6
+typedef struct PropertyTag_GetMACAddress_Request {
+    MailboxInterface_PropertyTag_t tag;
+}
+PropertyTag_GetMACAddress_Request_t;
+
+typedef struct PropertyTag_GetMACAddress_Response {
+    MailboxInterface_PropertyTag_t tag;
+    uint8_t mac_address[MAC_ADDRESS_SIZE];
+}
+PropertyTag_GetMACAddress_Response_t;
+
+// TODO: Add more request/reponse tags if needed
+
 bool bcm2711_set_power_state_on(mailbox_t *mbox, uint32_t device_id);
 
 int bcm2711_get_clock_rate(mailbox_t *mbox, uint32_t clock_id);
+
+bool bcm2711_get_mac_address(mailbox_t *mbox, uint8_t buffer[MAC_ADDRESS_SIZE]);
 
 // TODO: Add more mailbox functions if needed

--- a/libplatsupport/plat_include/bcm2837/platsupport/plat/mailbox_util.h
+++ b/libplatsupport/plat_include/bcm2837/platsupport/plat/mailbox_util.h
@@ -41,12 +41,20 @@ enum {
     DEVICE_ID_CCP2TX
 };
 
-// Property Tags: https://github.com/raspberrypi/firmware/wiki/Mailbox-property-interface
+////////////////////////////////////////////////////////////////////////////////
+//--------------------------------Property Tags-------------------------------//
+////////////////////////////////////////////////////////////////////////////////
+
+// See: https://github.com/raspberrypi/firmware/wiki/Mailbox-property-interface
 #define TAG_SET_POWER_STATE     0x00028001
 #define TAG_GET_CLOCK_RATE      0x00030002
 #define TAG_GET_MAC_ADDRESS     0x00010003
 
 // TODO: Add more property tags if needed
+
+////////////////////////////////////////////////////////////////////////////////
+//-----------------------------Request/Reponse Tags---------------------------//
+////////////////////////////////////////////////////////////////////////////////
 
 // See: https://github.com/raspberrypi/firmware/wiki/Mailbox-property-interface#set-power-state
 #define SET_POWER_STATE_OFF             (0u << 0)
@@ -95,6 +103,10 @@ typedef struct {
 PropertyTag_GetMACAddress_Response_t;
 
 // TODO: Add more request/reponse tags if needed
+
+////////////////////////////////////////////////////////////////////////////////
+//-----------------------------Mailbox Functions------------------------------//
+////////////////////////////////////////////////////////////////////////////////
 
 bool bcm2837_set_power_state_on(mailbox_t *mbox, uint32_t device_id);
 

--- a/libplatsupport/plat_include/bcm2837/platsupport/plat/mailbox_util.h
+++ b/libplatsupport/plat_include/bcm2837/platsupport/plat/mailbox_util.h
@@ -52,7 +52,7 @@ enum {
 #define SET_POWER_STATE_OFF             (0u << 0)
 #define SET_POWER_STATE_ON              (1u << 0)
 #define SET_POWER_STATE_WAIT            (1u << 1)
-typedef struct PropertyTag_SetPowerState_Request {
+typedef struct {
     MailboxInterface_PropertyTag_t tag;
     uint32_t device_id;
     uint32_t state;
@@ -60,7 +60,7 @@ typedef struct PropertyTag_SetPowerState_Request {
 PropertyTag_SetPowerState_Request_t;
 
 #define SET_POWER_STATE_NO_DEVICE       (1u << 1)
-typedef struct PropertyTag_SetPowerState_Response {
+typedef struct {
     MailboxInterface_PropertyTag_t tag;
     uint32_t device_id;
     uint32_t state;
@@ -68,13 +68,13 @@ typedef struct PropertyTag_SetPowerState_Response {
 PropertyTag_SetPowerState_Response_t;
 
 // See: https://github.com/raspberrypi/firmware/wiki/Mailbox-property-interface#get-clock-rate
-typedef struct PropertyTag_GetClockRate_Request {
+typedef struct {
     MailboxInterface_PropertyTag_t tag;
     uint32_t clock_id;
 }
 PropertyTag_GetClockRate_Request_t;
 
-typedef struct PropertyTag_GetClockRate_Response {
+typedef struct {
     MailboxInterface_PropertyTag_t tag;
     uint32_t clock_id;
     uint32_t rate;
@@ -83,12 +83,12 @@ PropertyTag_GetClockRate_Response_t;
 
 // See: https://github.com/raspberrypi/firmware/wiki/Mailbox-property-interface#get-board-mac-address
 #define MAC_ADDRESS_SIZE 6
-typedef struct PropertyTag_GetMACAddress_Request {
+typedef struct {
     MailboxInterface_PropertyTag_t tag;
 }
 PropertyTag_GetMACAddress_Request_t;
 
-typedef struct PropertyTag_GetMACAddress_Response {
+typedef struct {
     MailboxInterface_PropertyTag_t tag;
     uint8_t mac_address[MAC_ADDRESS_SIZE];
 }

--- a/libplatsupport/plat_include/bcm2837/platsupport/plat/mailbox_util.h
+++ b/libplatsupport/plat_include/bcm2837/platsupport/plat/mailbox_util.h
@@ -44,6 +44,7 @@ enum {
 // Property Tags: https://github.com/raspberrypi/firmware/wiki/Mailbox-property-interface
 #define TAG_SET_POWER_STATE     0x00028001
 #define TAG_GET_CLOCK_RATE      0x00030002
+#define TAG_GET_MAC_ADDRESS     0x00010003
 
 // TODO: Add more property tags if needed
 
@@ -80,8 +81,25 @@ typedef struct PropertyTag_GetClockRate_Response {
 }
 PropertyTag_GetClockRate_Response_t;
 
+// See: https://github.com/raspberrypi/firmware/wiki/Mailbox-property-interface#get-board-mac-address
+#define MAC_ADDRESS_SIZE 6
+typedef struct PropertyTag_GetMACAddress_Request {
+    MailboxInterface_PropertyTag_t tag;
+}
+PropertyTag_GetMACAddress_Request_t;
+
+typedef struct PropertyTag_GetMACAddress_Response {
+    MailboxInterface_PropertyTag_t tag;
+    uint8_t mac_address[MAC_ADDRESS_SIZE];
+}
+PropertyTag_GetMACAddress_Response_t;
+
+// TODO: Add more request/reponse tags if needed
+
 bool bcm2837_set_power_state_on(mailbox_t *mbox, uint32_t device_id);
 
 int bcm2837_get_clock_rate(mailbox_t *mbox, uint32_t clock_id);
+
+bool bcm2837_get_mac_address(mailbox_t *mbox, uint8_t buffer[MAC_ADDRESS_SIZE]);
 
 // TODO: Add more mailbox functions if needed

--- a/libplatsupport/src/plat/bcm2711/mailbox_util.c
+++ b/libplatsupport/src/plat/bcm2711/mailbox_util.c
@@ -12,6 +12,7 @@
  */
 
 #include <platsupport/plat/mailbox_util.h>
+#include <string.h>
 
 static int mbox_req_resp(mailbox_t   *mbox,
                          uint32_t    tag_id,
@@ -35,6 +36,13 @@ static int mbox_req_resp(mailbox_t   *mbox,
     }
 }
 
+/**
+ * Set power state on of device.
+ *
+ * @param mbox      Initialized mailbox driver instance
+ * @param device_id Device ID of device that should be activated.
+ * @return          true on success, false on failure
+ */
 bool bcm2711_set_power_state_on(mailbox_t *mbox, uint32_t device_id)
 {
     PropertyTag_SetPowerState_Request_t TagRequest = {
@@ -90,4 +98,35 @@ int bcm2711_get_clock_rate(mailbox_t *mbox, uint32_t clock_id)
     }
 
     return TagResponse.rate;
+}
+
+/**
+ * Get board MAC address.
+ *
+ * @param mbox      Initialized mailbox driver instance
+ * @param buffer    Buffer address to which each digit of the MAC address should
+ *                  be copied to.
+ * @return          true on success, false on failure
+ */
+bool bcm2711_get_mac_address(mailbox_t *mbox, uint8_t buffer[MAC_ADDRESS_SIZE])
+{
+    PropertyTag_GetMACAddress_Request_t TagRequest;
+    PropertyTag_GetMACAddress_Response_t TagResponse;
+
+    int status = mbox_req_resp(mbox,
+                               TAG_GET_MAC_ADDRESS,
+                               &TagRequest,
+                               sizeof(TagRequest),
+                               &TagResponse,
+                               sizeof(TagResponse));
+
+    if (MAILBOX_OK != status) {
+        ZF_LOGE("Failed to get mac address of board - error code: %d!", status);
+        memset(buffer, 0, MAC_ADDRESS_SIZE);
+        return false;
+    }
+
+    memcpy(buffer, TagResponse.mac_address, MAC_ADDRESS_SIZE);
+
+    return true;
 }


### PR DESCRIPTION
Extends the mailbox for the bcm2837 (rpi3) and bcm2711 (rpi4) with additional functionality. 