### PR TITLE
util_libs: license clarification

### DIFF
--- a/libutils/include/utils/config.h
+++ b/libutils/include/utils/config.h
@@ -1,7 +1,7 @@
 /*
  * Copyright 2017, Data61, CSIRO (ABN 41 687 119 230)
  *
- * SPDX-License-Identifier: GPL-2.0-only
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once


### PR DESCRIPTION
This file was mistakenly tagged as GPL, when it should be BSD. Commit
a7130f9f836 previously already fixed the license text, but not the tag,
which in the SPDX conversion then got lost.
