### PR TITLE
libplatsupport,imx: Update timer drivers to handle more boundary-conditions/edge cases

### DIFF
--- a/libplatsupport/src/mach/imx/epit/epit.c
+++ b/libplatsupport/src/mach/imx/epit/epit.c
@@ -143,6 +143,9 @@ int epit_set_timeout(epit_t *epit, uint64_t ns, bool periodic)
     /* Set counter modulus - this effectively sets the timeouts to us but doesn't
      * overflow as fast. */
     uint64_t counterValue = (uint64_t)(IPG_FREQ / (epit->prescaler + 1)) * (ns / 1000ULL);
+    if (counterValue == 0) {
+        return ETIME;
+    }
 
     return epit_set_timeout_ticks(epit, counterValue, periodic);
 }

--- a/libplatsupport/src/mach/imx/ltimer.c
+++ b/libplatsupport/src/mach/imx/ltimer.c
@@ -46,6 +46,9 @@ static int set_timeout(void *data, uint64_t ns, timeout_type_t type)
 
     if (type == TIMEOUT_ABSOLUTE) {
         uint64_t current_time = imx_get_time(&imx_ltimer->timers);
+        if (ns < current_time) {
+            return ETIME;
+        }
         ns -= current_time;
     }
 


### PR DESCRIPTION
- When programming timeouts using the ltimer, if the timeout is too soon, ETIME needs to be returned instead of attempting to program a timeout which may end up being and underflowed timer value otherwise
- When reading the upcounter, handle the situation when the counter ticks over between reading it and reading the overflow hardware bit.