### PR TITLE
Add Quartz64 support

### DIFF
--- a/libplatsupport/CMakeLists.txt
+++ b/libplatsupport/CMakeLists.txt
@@ -82,7 +82,7 @@ elseif(${KernelArch} STREQUAL "riscv")
     list(APPEND irqchip_modules "-Wl,--undefined=riscv_plic_ptr")
 endif()
 
-if(KernelPlatformQEMUArmVirt)
+if(KernelPlatformQEMUArmVirt OR KernelPlatformQuartz64)
     if(KernelArmExportPCNTUser AND KernelArmExportPTMRUser)
         list(APPEND deps src/arch/arm/generic_ltimer.c)
     endif()

--- a/libplatsupport/plat_include/quartz64/platsupport/plat/clock.h
+++ b/libplatsupport/plat_include/quartz64/platsupport/plat/clock.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2019, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+enum clk_id {
+    CLK_MASTER,
+    NCLOCKS,
+};
+
+enum clock_gate {
+    NCLKGATES
+};

--- a/libplatsupport/plat_include/quartz64/platsupport/plat/i2c.h
+++ b/libplatsupport/plat_include/quartz64/platsupport/plat/i2c.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2019, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <platsupport/io.h>
+
+enum i2c_id {
+    NI2C
+};

--- a/libplatsupport/plat_include/quartz64/platsupport/plat/serial.h
+++ b/libplatsupport/plat_include/quartz64/platsupport/plat/serial.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#define UART0_PADDR  0xFDD50000
+#define UART1_PADDR  0xFE650000
+#define UART2_PADDR  0xFE660000
+#define UART3_PADDR  0xFE670000
+#define UART4_PADDR  0xFE680000
+
+#define UART0_IRQ    148
+#define UART1_IRQ    149
+#define UART2_IRQ    150
+#define UART3_IRQ    151
+#define UART4_IRQ    152
+
+enum chardev_id {
+    RP_UART0,
+    RP_UART1,
+    RP_UART2,
+    RP_UART3,
+    RP_UART4,
+    /* Aliases */
+    PS_SERIAL0 = RP_UART0,
+    PS_SERIAL1 = RP_UART1,
+    PS_SERIAL2 = RP_UART2,
+    PS_SERIAL3 = RP_UART3,
+    PS_SERIAL4 = RP_UART4,
+    /* defaults */
+    PS_SERIAL_DEFAULT = RP_UART2
+};
+
+#define DEFAULT_SERIAL_PADDR UART2_PADDR
+#define DEFAULT_SERIAL_INTERRUPT UART2_IRQ

--- a/libplatsupport/src/plat/quartz64/chardev.c
+++ b/libplatsupport/src/plat/quartz64/chardev.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+/**
+ * Contains the definition for all character devices on this platform.
+ * Currently this is just a simple patch.
+ */
+
+#include "../../chardev.h"
+#include "../../common.h"
+#include <utils/util.h>
+
+static const int uart1_irqs[] = {UART1_IRQ, -1};
+static const int uart2_irqs[] = {UART2_IRQ, -1};
+static const int uart3_irqs[] = {UART3_IRQ, -1};
+static const int uart4_irqs[] = {UART4_IRQ, -1};
+
+
+#define UART_DEFN(devid) {          \
+    .id      = RP_UART##devid,    \
+    .paddr   = UART##devid##_PADDR, \
+    .size    = BIT(12),             \
+    .irqs    = uart##devid##_irqs,  \
+    .init_fn = &uart_init           \
+}
+
+
+static const struct dev_defn dev_defn[] = {
+    UART_DEFN(1),
+    UART_DEFN(2),
+    UART_DEFN(3),
+    UART_DEFN(4),
+};
+
+struct ps_chardevice *
+ps_cdev_init(enum chardev_id id, const ps_io_ops_t *o, struct ps_chardevice *d)
+{
+    unsigned int i;
+    for (i = 0; i < ARRAY_SIZE(dev_defn); i++) {
+        if (dev_defn[i].id == id) {
+            return (dev_defn[i].init_fn(dev_defn + i, o, d)) ? NULL : d;
+        }
+    }
+    return NULL;
+}

--- a/libplatsupport/src/plat/quartz64/serial.c
+++ b/libplatsupport/src/plat/quartz64/serial.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <string.h>
+#include <stdlib.h>
+#include <platsupport/serial.h>
+#include "../../chardev.h"
+
+#define RHR         0x00
+#define THR         0x00
+#define IER         0x04
+#define LSR         0x14
+#define RHR_MASK    MASK(8)
+#define IER_RHRIT   BIT(0)
+#define LSR_TXFIFOE BIT(5)
+#define LSR_RXFIFOE BIT(0)
+
+#define REG_PTR(base, off)     ((volatile uint32_t *)((base) + (off)))
+
+int uart_getchar(ps_chardevice_t *d)
+{
+    int ch = EOF;
+
+    if (*REG_PTR(d->vaddr, LSR) & LSR_RXFIFOE) {
+        ch = *REG_PTR(d->vaddr, RHR) & RHR_MASK;
+    }
+    return ch;
+}
+
+int uart_putchar(ps_chardevice_t *d, int c)
+{
+    if (c == '\n' && (d->flags & SERIAL_AUTO_CR)) {
+        uart_putchar(d, '\r');
+    }
+    while (!(*REG_PTR(d->vaddr, LSR) & LSR_TXFIFOE)) {
+        continue;
+    }
+    *REG_PTR(d->vaddr, THR) = c;
+
+    return c;
+}
+
+static void uart_handle_irq(ps_chardevice_t *d UNUSED)
+{
+    /* nothing to do */
+}
+
+int uart_init(const struct dev_defn *defn,
+              const ps_io_ops_t *ops,
+              ps_chardevice_t *dev)
+{
+    memset(dev, 0, sizeof(*dev));
+    void *vaddr = chardev_map(defn, ops);
+    if (vaddr == NULL) {
+        return -1;
+    }
+
+    /* Set up all the  device properties. */
+    dev->id         = defn->id;
+    dev->vaddr      = (void *)vaddr;
+    dev->read       = &uart_read;
+    dev->write      = &uart_write;
+    dev->handle_irq = &uart_handle_irq;
+    dev->irqs       = defn->irqs;
+    dev->ioops      = *ops;
+    dev->flags      = SERIAL_AUTO_CR;
+
+    *REG_PTR(dev->vaddr, IER) = IER_RHRIT;
+    return 0;
+}


### PR DESCRIPTION
This adds support for the Pine64 Quartz64 and other devices based on
the Rockchip RK3566. The platform support is adapted from the
Rockpro64 code, except that the RK356x has A55 cores, and adjusting
for the fact that the ARM Generic Timer is the only on-chip timer
available.

Test with: seL4/seL4#727, seL4_tools#134, seL4/sel4test#83