### PR TITLE
fix bcm2837 mini uart reg offset and enable it read interrupt

### DIFF
--- a/libplatsupport/src/plat/bcm2837/serial.c
+++ b/libplatsupport/src/plat/bcm2837/serial.c
@@ -40,6 +40,7 @@
 
 #define MU_IIR_INTID 0x6
 #define MU_IIR_HOLD_EMPTY 0x2
+#define MU_IER_ENABLE_READ_INTERRUPT BIT(0)
 
 static void
 uart_handle_irq(ps_chardevice_t* d UNUSED)
@@ -83,6 +84,8 @@ int uart_init(const struct dev_defn* defn,
     dev->irqs       = defn->irqs;
     dev->ioops      = *ops;
     dev->flags      = SERIAL_AUTO_CR;
+    
+    *REG_PTR(dev->vaddr, MU_IER) |= MU_IER_ENABLE_READ_INTERRUPT;
 
     return 0;
 }

--- a/libplatsupport/src/plat/bcm2837/serial.c
+++ b/libplatsupport/src/plat/bcm2837/serial.c
@@ -17,8 +17,8 @@
 #define MU_IO       0x40
 /* When DLAB=1, MU_IIR is a baud rate register.
  * Otherwise IRQ enable */
-#define MU_IIR      0x44
-#define MU_IER      0x48
+#define MU_IIR      0x48
+#define MU_IER      0x44
 #define MU_LCR      0x4C
 #define MU_MCR      0x50
 #define MU_LSR      0x54
@@ -38,6 +38,9 @@
 #define MU_LCR_BREAK     BIT(6)
 #define MU_LCR_DATASIZE  BIT(0)
 
+#define MU_IIR_INTID 0x6
+#define MU_IIR_HOLD_EMPTY 0x2
+
 static void
 uart_handle_irq(ps_chardevice_t* d UNUSED)
 {
@@ -53,6 +56,9 @@ int uart_putchar(ps_chardevice_t* d, int c)
 
 int uart_getchar(ps_chardevice_t* d UNUSED)
 {
+    if ((*REG_PTR(d->vaddr, MU_IIR) & MU_IIR_INTID) == MU_IIR_HOLD_EMPTY) {
+        return -1;
+    }
     while ( !(*REG_PTR(d->vaddr, MU_LSR) & MU_LSR_DATAREADY) );
     return *REG_PTR(d->vaddr, MU_IO);
 }


### PR DESCRIPTION
fix bcm2837 mini uart reg offset and enable it read interrupt