### PR TITLE
fix: add missing typedef for imx6 `eth_plat.h`

### DIFF
--- a/libethdrivers/plat_include/imx6/ethdrivers/plat/eth_plat.h
+++ b/libethdrivers/plat_include/imx6/ethdrivers/plat/eth_plat.h
@@ -14,7 +14,7 @@
 
 struct enet *get_enet_from_driver(struct eth_driver *driver);
 
-enum {
+typedef enum {
     NIC_CONFIG_FORCE_MAC        = 1u << 0, /**< Use MAC from config (if not 0) */
     NIC_CONFIG_PROMISCUOUS_MODE = 1u << 1, /**< Enable promiscuous mode */
     NIC_CONFIG_DROP_FRAME_CRC   = 1u << 2, /**< Drop ethernet frame CRC */


### PR DESCRIPTION
The `nic_config_flags_t` enum in the imx6's `eth_plat.h` header is missing the `typedef` keyword, this causes a build error when multiple source files include the header.