### PR TITLE
trivial: Fix typo in linker arg for tx2 ethernet

### DIFF
--- a/libethdrivers/CMakeLists.txt
+++ b/libethdrivers/CMakeLists.txt
@@ -111,7 +111,7 @@ string(
     ","
     DriverModules
     "-Wl"
-    "--undefined=tx_ether_qos_ptr"
+    "--undefined=tx2_ether_qos_ptr"
     "--undefined=zynq7000_gem_ptr"
     "--undefined=imx_fec_ptr"
     "--undefined=odroidc2_ethernet_ptr"


### PR DESCRIPTION
The symbol name is supposed to be tx2_ether_qos_ptr.

Signed-off-by: Kent McLeod <kent@kry10.com>