### PR TITLE
libplatsupport: use const qualifier

### DIFF
--- a/libplatsupport/mach_include/bcm/platsupport/mach/system_timer.h
+++ b/libplatsupport/mach_include/bcm/platsupport/mach/system_timer.h
@@ -48,7 +48,7 @@ typedef struct {
 typedef struct {
     uint32_t channel;
     uint32_t frequency;
-    char *fdt_path;
+    const char *fdt_path;
     uint32_t fdt_reg_choice;
     uint32_t fdt_irq_choice;
 } bcm_system_timer_config_t;

--- a/libplatsupport/mach_include/exynos/platsupport/mach/pwm.h
+++ b/libplatsupport/mach_include/exynos/platsupport/mach/pwm.h
@@ -66,6 +66,6 @@ static UNUSED timer_properties_t pwm_properties = {
 
 uint64_t pwm_get_time(pwm_t *pwm);
 int pwm_set_timeout(pwm_t *pwm, uint64_t ns, bool periodic);
-int pwm_init(pwm_t *pwm, ps_io_ops_t ops, char *fdt_path, ltimer_callback_fn_t user_cb_fn, void *user_cb_token);
+int pwm_init(pwm_t *pwm, ps_io_ops_t ops, const char *fdt_path, ltimer_callback_fn_t user_cb_fn, void *user_cb_token);
 void pwm_destroy(pwm_t *pwm);
 int pwm_reset(pwm_t *pwm);

--- a/libplatsupport/mach_include/omap/platsupport/mach/gpt.h
+++ b/libplatsupport/mach_include/omap/platsupport/mach/gpt.h
@@ -77,7 +77,7 @@ static UNUSED timer_properties_t rel_gpt_properties = {
  *
  * @returns 0 if successful. Error code if not.
  */
-int gpt_create(gpt_t *gpt, ps_io_ops_t ops, char *fdt_path, ltimer_callback_fn_t user_cb_fn, void *user_cb_token);
+int gpt_create(gpt_t *gpt, ps_io_ops_t ops, const char *fdt_path, ltimer_callback_fn_t user_cb_fn, void *user_cb_token);
 
 /**
  * Functions to get a GPT timer which is programmed to overflow

--- a/libplatsupport/plat_include/am335x/platsupport/plat/timer.h
+++ b/libplatsupport/plat_include/am335x/platsupport/plat/timer.h
@@ -24,7 +24,7 @@ static UNUSED timer_properties_t dmt_properties = {
 };
 
 typedef struct {
-    char *fdt_path;
+    const char *fdt_path;
     ltimer_callback_fn_t user_cb_fn;
     void *user_cb_token;
     ltimer_event_t user_cb_event;

--- a/libplatsupport/plat_include/fvp/platsupport/plat/sp804.h
+++ b/libplatsupport/plat_include/fvp/platsupport/plat/sp804.h
@@ -57,7 +57,7 @@ typedef struct {
 } sp804_t;
 
 typedef struct {
-    char *fdt_path;
+    const char *fdt_path;
     ltimer_callback_fn_t user_cb_fn;
     void *user_cb_token;
     ltimer_event_t user_cb_event;

--- a/libplatsupport/plat_include/hikey/platsupport/plat/dmt.h
+++ b/libplatsupport/plat_include/hikey/platsupport/plat/dmt.h
@@ -51,7 +51,7 @@ typedef struct {
 } dmt_t;
 
 typedef struct {
-    char *fdt_path;
+    const char *fdt_path;
     ltimer_callback_fn_t user_cb_fn;
     void *user_cb_token;
     ltimer_event_t user_cb_event;

--- a/libplatsupport/plat_include/rockpro64/platsupport/plat/timer.h
+++ b/libplatsupport/plat_include/rockpro64/platsupport/plat/timer.h
@@ -50,7 +50,7 @@ typedef struct {
 } rk_t;
 
 typedef struct {
-    char *fdt_path;
+    const char *fdt_path;
     ltimer_callback_fn_t user_cb_fn;
     void *user_cb_token;
     ltimer_event_t user_cb_event;

--- a/libplatsupport/plat_include/tqma8xqp1gb/platsupport/plat/gpt.h
+++ b/libplatsupport/plat_include/tqma8xqp1gb/platsupport/plat/gpt.h
@@ -36,7 +36,7 @@ typedef struct gpt {
     enum gpt_timeout_type timeout_type;
 } gpt_t;
 
-int gpt_init(gpt_t *gpt, char *fdt_path, ps_io_ops_t ops, ltimer_callback_fn_t user_callback,
+int gpt_init(gpt_t *gpt, const char *fdt_path, ps_io_ops_t ops, ltimer_callback_fn_t user_callback,
              void *user_callback_token);
 int gpt_get_time(gpt_t *gpt, uint64_t *time);
 int gpt_set_timeout(gpt_t *gpt, uint64_t ns, timeout_type_t type);

--- a/libplatsupport/src/ltimer.h
+++ b/libplatsupport/src/ltimer.h
@@ -42,7 +42,7 @@ static inline void handle_irq_wrapper(void *data, ps_irq_acknowledge_fn_t acknow
 }
 
 static int helper_fdt_alloc_simple(
-    ps_io_ops_t *ops, char *fdt_path,
+    ps_io_ops_t *ops, const char *fdt_path,
     unsigned reg_choice, unsigned irq_choice,
     void **vmap, pmem_region_t *pmem, irq_id_t *irq_id,
     irq_callback_fn_t handler, void *handler_token

--- a/libplatsupport/src/mach/exynos/pwm.c
+++ b/libplatsupport/src/mach/exynos/pwm.c
@@ -305,7 +305,7 @@ void pwm_destroy(pwm_t *pwm)
     }
 }
 
-int pwm_init(pwm_t *pwm, ps_io_ops_t ops, char *fdt_path, ltimer_callback_fn_t user_cb_fn, void *user_cb_token)
+int pwm_init(pwm_t *pwm, ps_io_ops_t ops, const char *fdt_path, ltimer_callback_fn_t user_cb_fn, void *user_cb_token)
 {
     int error;
     ps_fdt_cookie_t *fdt_cookie;

--- a/libplatsupport/src/mach/omap/gpt.c
+++ b/libplatsupport/src/mach/omap/gpt.c
@@ -386,7 +386,7 @@ void gpt_destroy(gpt_t *gpt)
     }
 }
 
-int gpt_create(gpt_t *gpt, ps_io_ops_t ops, char *fdt_path, ltimer_callback_fn_t user_cb_fn, void *user_cb_token)
+int gpt_create(gpt_t *gpt, ps_io_ops_t ops, const char *fdt_path, ltimer_callback_fn_t user_cb_fn, void *user_cb_token)
 {
     int error;
 

--- a/libplatsupport/src/plat/tqma8xqp1gb/gpt.c
+++ b/libplatsupport/src/plat/tqma8xqp1gb/gpt.c
@@ -214,7 +214,8 @@ static int allocate_irq_callback(ps_irq_t irq, unsigned curr_num, size_t num_irq
     return 0;
 }
 
-int gpt_init(gpt_t *gpt, char *fdt_path, ps_io_ops_t ops, ltimer_callback_fn_t user_callback, void *user_callback_token)
+int gpt_init(gpt_t *gpt, const char *fdt_path, ps_io_ops_t ops, ltimer_callback_fn_t user_callback,
+             void *user_callback_token)
 {
     assert(gpt != NULL);
 


### PR DESCRIPTION
Ensure the const correctness is kept, this avoids compiler warnings.
