### PR TITLE
Fix compilation warning about implicit conversion of a negative value

### DIFF
--- a/libcpio/src/cpio.c
+++ b/libcpio/src/cpio.c
@@ -208,7 +208,7 @@ const void *cpio_get_file(const void *archive, unsigned long len, const char *na
         if (error) {
             return NULL;
         }
-        if (cpio_strncmp(header_info.filename, name, -1) == 0) {
+        if (cpio_strncmp(header_info.filename, name, (unsigned long)(-1)) == 0) {
             break;
         }
         len = cpio_len_next(len, header, header_info.next);


### PR DESCRIPTION
It is converted to an unsigned type: an "int -1" to "unsigned long".