### PR TITLE
Fix compilation warning about unreachable code

### DIFF
--- a/libcpio/src/cpio.c
+++ b/libcpio/src/cpio.c
@@ -240,7 +240,7 @@ int cpio_info(const void *archive, unsigned long len, struct cpio_info *info)
             return error;
         } else if (error == 1) {
             /* EOF */
-            return 0;
+            break;
         }
         info->file_count++;
         len = cpio_len_next(len, header, header_info.next);


### PR DESCRIPTION
All paths inside the endless loop (`while (1)`) end in a `return`,
but the function contained another `return 0` at the end of the body,
which was never reached.

Use the EOF path (which returns a 0) inside the loop to jump to that `return 0`.
