### PR TITLE
github: bump GitHub action versions

### DIFF
--- a/.github/workflows/sel4test-hw.yml
+++ b/.github/workflows/sel4test-hw.yml
@@ -46,7 +46,7 @@ jobs:
         compiler: ${{ matrix.compiler }}
         sha: ${{ github.event.pull_request.head.sha }}
     - name: Upload images
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: images-${{ matrix.march }}-${{ matrix.compiler }}
         path: '*-images.tar.gz'
@@ -78,13 +78,13 @@ jobs:
       matrix: ${{ fromJson(needs.the_matrix.outputs.matrix) }}
     steps:
       - name: Get machine queue
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: seL4/machine_queue
           path: machine_queue
           token: ${{ secrets.PRIV_REPO_TOKEN }}
       - name: Download image
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: images-${{ matrix.march }}-${{ matrix.compiler }}
       - name: Run


### PR DESCRIPTION
Use the more recent Node.js 16 actions; removes warnings.