### PR TITLE
libplatsupport: use proper type

### DIFF
--- a/libplatsupport/src/arch/arm/delay.c
+++ b/libplatsupport/src/arch/arm/delay.c
@@ -30,7 +30,7 @@
 static unsigned long cpufreq_hint = DEFAULT_CPUFREQ;
 #define CYCLES_PER_US (cpufreq_hint / 1000000)
 
-static void ps_do_cycle_delay(int32_t cycles)
+static void ps_do_cycle_delay(size_t cycles)
 {
     /* Loop while the number of required instructions is +ve
      * We unfold the loop to avoid branch predictor optimisation.

--- a/libplatsupport/src/arch/arm/delay.c
+++ b/libplatsupport/src/arch/arm/delay.c
@@ -30,8 +30,6 @@
 static unsigned long cpufreq_hint = DEFAULT_CPUFREQ;
 #define CYCLES_PER_US (cpufreq_hint / 1000000)
 
-void ps_udelay(unsigned long us);
-
 static void ps_do_cycle_delay(int32_t cycles)
 {
     /* Loop while the number of required instructions is +ve


### PR DESCRIPTION
Avoid a clang warning.

```
sel4_util_libs/libplatsupport/src/arch/arm/delay.c:60:29: warning: value size does not match register size specified by the constraint and modifier [-Wasm-operand-widths]
        "    bpl 1b" : "+r"(cycles));
```