### PR TITLE
trivial: Fix clang warning about register width

### DIFF
--- a/libplatsupport/src/arch/arm/delay.c
+++ b/libplatsupport/src/arch/arm/delay.c
@@ -32,7 +32,7 @@ static unsigned long cpufreq_hint = DEFAULT_CPUFREQ;
 
 void ps_udelay(unsigned long us);
 
-static void ps_do_cycle_delay(int32_t cycles)
+static void ps_do_cycle_delay(intptr_t cycles)
 {
     /* Loop while the number of required instructions is +ve
      * We unfold the loop to avoid branch predictor optimisation.


### PR DESCRIPTION
Changing the input argument to be word-sized avoids the inline assembly overwriting more of the register on 64-bit architectures and appeases the compiler.


Fixes warnings like:
```
/tmp/tmp.3CplW6S5Lu/projects/util_libs/libplatsupport/src/arch/arm/delay.c:60:29: warning: value size does not match register size specified by the constraint and modifier [-Wasm-operand-widths]
        "    bpl 1b" : "+r"(cycles));
                            ^
/tmp/tmp.3CplW6S5Lu/projects/util_libs/libplatsupport/src/arch/arm/delay.c:55:23: note: use constraint modifier "w"
        "    subs %0, %0, #1;"  /* 12 */
                      ^~
                      %w0
```