### PR TITLE
libethdrivers: bring back linker options

### DIFF
--- a/libethdrivers/CMakeLists.txt
+++ b/libethdrivers/CMakeLists.txt
@@ -105,7 +105,10 @@ if("${KernelPlatform}" STREQUAL "tx2")
     target_link_libraries(ethdrivers platsupportports)
 endif()
 
-# Get the list of driver modules
+# Provide the driver modules by forcing the linker to put these symbols in the
+# library, instead of discarding them as unused. Using target_link_libraries()
+# is a bit of a hack, target_link_options() would be the better way, but this
+# requires CMake v3.13.
 string(
     JOIN
     ","
@@ -116,6 +119,7 @@ string(
     "--undefined=imx_fec_ptr"
     "--undefined=odroidc2_ethernet_ptr"
 )
+target_link_libraries(ethdrivers "${DriverModules}")
 
 target_include_directories(
     ethdrivers


### PR DESCRIPTION
This line `target_link_libraries(ethdrivers "${DriverModules}")` was removed accidentally in commit 12a8adba (PR https://github.com/seL4/util_libs/pull/136) and this broke support for the various ethernet drivers. I'm a bit surprised that this has not be noticed, but it seem the linker sometimes still keeps modue sections. However, we ran into problems when adding a new driver, as the new module never ended up in the the CAmkES component's binary.

I'm also making the comment a bit more verbose and add a note about better CMake usage once we update the containers (see https://github.com/seL4/seL4/issues/827)