### PR TITLE
libethdrivers: make zynqmp driver usable

### DIFF
--- a/libethdrivers/CMakeLists.txt
+++ b/libethdrivers/CMakeLists.txt
@@ -118,6 +118,7 @@ string(
     "-Wl"
     "--undefined=tx2_ether_qos_ptr"
     "--undefined=zynq7000_gem_ptr"
+    "--undefined=zynqmp_gem_ptr"
     "--undefined=imx_fec_ptr"
     "--undefined=odroidc2_ethernet_ptr"
 )

--- a/libethdrivers/src/plat/zynqmp/zynqmp.c
+++ b/libethdrivers/src/plat/zynqmp/zynqmp.c
@@ -564,7 +564,7 @@ int ethif_zynqmp_init_module(ps_io_ops_t *io_ops, const char *dev_path)
 }
 
 static const char *compatible_strings[] = {
-    "cdns,zynq-gem",
+    "cdns,zynqmp-gem",
     "cdns,gem",
     NULL
 };


### PR DESCRIPTION
- fix compatibility string. Seems this changed in at some point in the device tree? Or did this ever work, because that seems the zynq7000 string? 
- add zynqmp driver to the list of symbols kept, so the linker will not throw this out.

@chrisguikema I'm a bit confused actually, how do things work for you without these changes?