### PR TITLE
libethdrivers: add entry for zynqmp driver module

### DIFF
--- a/libethdrivers/CMakeLists.txt
+++ b/libethdrivers/CMakeLists.txt
@@ -118,6 +118,7 @@ string(
     "-Wl"
     "--undefined=tx2_ether_qos_ptr"
     "--undefined=zynq7000_gem_ptr"
+    "--undefined=zynqmp_gem_ptr"
     "--undefined=imx_fec_ptr"
     "--undefined=odroidc2_ethernet_ptr"
 )


### PR DESCRIPTION
So that the zynqmp Ethernet driver can be found by `find_compatible_driver_module`.