### PR TITLE
hifive: Check if overflow IRQ is actually pending

### DIFF
--- a/libplatsupport/src/plat/hifive/pwm.c
+++ b/libplatsupport/src/plat/hifive/pwm.c
@@ -93,7 +93,7 @@ int pwm_set_timeout(pwm_t *pwm, uint64_t ns, bool periodic)
 
 void pwm_handle_irq(pwm_t *pwm, uint32_t irq)
 {
-    if(pwm->mode == UPCOUNTER) {
+    if (pwm->mode == UPCOUNTER && (pwm->pwm_map->pwmcfg & PWMCMP0IP)) {
         pwm->time_h++;
     }
 


### PR DESCRIPTION
Timer may have been reset, or the overflow may be already handled by pwm_get_time().

This fixes sel4test [issue 91](https://github.com/seL4/sel4test/issues/91).