### PR TITLE
libplatsupport: use proper format specifier

### DIFF
--- a/libplatsupport/src/plat/hifive/ltimer.c
+++ b/libplatsupport/src/plat/hifive/ltimer.c
@@ -63,7 +63,7 @@ static pmem_region_t pmems[] = {
 #define N_IRQS ARRAY_SIZE(irqs)
 #define N_PMEMS ARRAY_SIZE(pmems)
 
- size_t get_num_irqs(void *data)
+size_t get_num_irqs(void *data)
 {
     return N_IRQS;
 }

--- a/libplatsupport/src/plat/hifive/ltimer.c
+++ b/libplatsupport/src/plat/hifive/ltimer.c
@@ -101,7 +101,7 @@ static int ltimer_handle_irq(void *data, ps_irq_t *irq)
         pwm_handle_irq(&timers->pwm_ltimers[TIMEOUT_TIMER].pwm, irq->irq.number);
         event = LTIMER_TIMEOUT_EVENT;
     } else {
-        ZF_LOGE("Invalid IRQ number: %d received.\n", irq_number);
+        ZF_LOGE("Invalid IRQ number: %ld received.\n", irq_number);
     }
 
     if (timers->user_callback) {


### PR DESCRIPTION
This avoid a build warning with clang, which can also be found in CI (see e.g. https://github.com/seL4/seL4/actions/runs/8085439570/job/22092970792)

```
  [78/256] Building C object apps/sel4test-driver/util_libs/libplatsupport/CMakeFiles/platsupport.dir/src/plat/hifive/ltimer.c.obj
  /github/workspace/projects/util_libs/libplatsupport/src/plat/hifive/ltimer.c:104:55: warning: format specifies type 'int' but the argument has type 'long' [-Wformat]
          ZF_LOGE("Invalid IRQ number: %d received.\n", irq_number);
                                       ~~               ^~~~~~~~~~
                                       %ld
  /github/workspace/projects/util_libs/libutils/include/utils/zf_log.h:359:43: note: expanded from macro 'ZF_LOGE'
                          _ZF_LOG_IMP(ZF_LOG_ERROR, _ZF_LOG_TAG, __VA_ARGS__)
                                                                 ^~~~~~~~~~~
  /github/workspace/projects/util_libs/libutils/include/utils/zf_log.h:302:18: note: expanded from macro '_ZF_LOG_IMP'
                                                          lvl, tag, __VA_ARGS__); \
                                                                    ^~~~~~~~~~~
```