### PR TITLE
CI: cancel older concurrent PR runs

### DIFF
--- a/.github/workflows/sel4test-hw.yml
+++ b/.github/workflows/sel4test-hw.yml
@@ -6,7 +6,7 @@
 #
 # See sel4test-hw/builds.yml in the repo seL4/ci-actions for configs.
 
-name: seL4Test HW
+name: seL4Test-HW
 
 on:
   # needs PR target for secrets access; guard by requiring label
@@ -16,6 +16,11 @@ on:
 # downgrade permissions to read-only as you would have in a standard PR action
 permissions:
   contents: read
+
+# Cancel older runs to reduce the load, especially on the machine queue.
+concurrency:
+  group: ${{ github.workflow }}-pr-${{ github.event.number }}
+  cancel-in-progress: true
 
 jobs:
   hw-build:

--- a/.github/workflows/sel4test-hw.yml
+++ b/.github/workflows/sel4test-hw.yml
@@ -80,7 +80,6 @@ jobs:
         with:
           repository: seL4/machine_queue
           path: machine_queue
-          token: ${{ secrets.PRIV_REPO_TOKEN }}
       - name: Download image
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/sel4test-sim.yml
+++ b/.github/workflows/sel4test-sim.yml
@@ -6,12 +6,19 @@
 #
 # See sel4test-sim/builds.yml in the repo seL4/ci-actions for configs.
 
-name: seL4Test Sim
+name: seL4Test-Sim
 
 on:
   push:
     branches: [master]
   pull_request:
+
+# Cancel older runs to reduce the load. The workflow also runs on pushes to
+# the master brnach, but skipping or cancellation will not happen there
+# practically due to the unique run ID.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || format('run-{0}', github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   simulation:


### PR DESCRIPTION
apply what has been done in:
- https://github.com/seL4/seL4/pull/1177
- https://github.com/seL4/seL4/pull/1178

for handling both PRs and pushes see also what is done here
- https://github.com/seL4/seL4/pull/1194