### PR TITLE
libplatsupport: use ltimer prefix for functions

### DIFF
--- a/libplatsupport/src/arch/arm/generic_ltimer.c
+++ b/libplatsupport/src/arch/arm/generic_ltimer.c
@@ -195,7 +195,7 @@ int ltimer_default_init(ltimer_t *ltimer, ps_io_ops_t ops, ltimer_callback_fn_t 
         return error;
     }
     generic_ltimer->timer_irq_id = ps_irq_register(&ops.irq_ops, *generic_ltimer->callback_data.irq,
-                                                   handle_irq_wrapper, &generic_ltimer->callback_data);
+                                                   ltimer_handle_irq_wrapper, &generic_ltimer->callback_data);
     if (generic_ltimer->timer_irq_id < 0) {
         destroy(ltimer->data);
         return EIO;

--- a/libplatsupport/src/ltimer.h
+++ b/libplatsupport/src/ltimer.h
@@ -24,7 +24,7 @@ typedef struct {
  *
  * Note that this wrapper assumes that the interrupts are level triggered.
  */
-static inline void handle_irq_wrapper(void *data, ps_irq_acknowledge_fn_t acknowledge_fn, void *ack_data)
+static inline void ltimer_handle_irq_wrapper(void *data, ps_irq_acknowledge_fn_t acknowledge_fn, void *ack_data)
 {
     assert(data);
 
@@ -92,7 +92,7 @@ static int helper_fdt_alloc_simple(
     return 0;
 }
 
-static int get_resolution_dummy(void *data, uint64_t *resolution)
+static int ltimer_get_resolution_dummy(void *data, uint64_t *resolution)
 {
     return ENOSYS;
 }
@@ -108,7 +108,7 @@ static int create_ltimer_simple(
     assert(ltimer != NULL);
 
     ltimer->get_time = get_time;
-    ltimer->get_resolution = get_resolution_dummy;
+    ltimer->get_resolution = ltimer_get_resolution_dummy;
     ltimer->set_timeout = set_timeout;
     ltimer->reset = reset;
     ltimer->destroy = destroy;

--- a/libplatsupport/src/plat/ariane/ltimer.c
+++ b/libplatsupport/src/plat/ariane/ltimer.c
@@ -232,7 +232,7 @@ int ltimer_default_init(ltimer_t *ltimer, ps_io_ops_t ops, ltimer_callback_fn_t 
         destroy(ltimer->data);
         return error;
     }
-    timer->irq_id = ps_irq_register(&ops.irq_ops, *timer->callback_data.irq, handle_irq_wrapper,
+    timer->irq_id = ps_irq_register(&ops.irq_ops, *timer->callback_data.irq, ltimer_handle_irq_wrapper,
                                     &timer->callback_data);
     if (timer->irq_id < 0) {
         destroy(ltimer->data);

--- a/libplatsupport/src/plat/hifive/ltimer.c
+++ b/libplatsupport/src/plat/hifive/ltimer.c
@@ -248,7 +248,7 @@ int ltimer_default_init(ltimer_t *ltimer, ps_io_ops_t ops, ltimer_callback_fn_t 
         timers->callback_datas[i].ltimer = ltimer;
         timers->callback_datas[i].irq = &irqs[i];
         timers->callback_datas[i].irq_handler = ltimer_handle_irq;
-        timers->timer_irq_ids[i] = ps_irq_register(&ops.irq_ops, irqs[i], handle_irq_wrapper,
+        timers->timer_irq_ids[i] = ps_irq_register(&ops.irq_ops, irqs[i], ltimer_handle_irq_wrapper,
                                                    &timers->callback_datas[i]);
         if (timers->timer_irq_ids[i] < 0) {
             destroy(ltimer->data);

--- a/libplatsupport/src/plat/odroidc2/ltimer.c
+++ b/libplatsupport/src/plat/odroidc2/ltimer.c
@@ -210,7 +210,7 @@ int ltimer_default_init(ltimer_t *ltimer, ps_io_ops_t ops, ltimer_callback_fn_t 
     odroidc2_timer->callback_data.irq_handler = handle_irq;
     odroidc2_timer->callback_data.irq = &irqs[0];
 
-    odroidc2_timer->timer_irq_id = ps_irq_register(&ops.irq_ops, irqs[0], handle_irq_wrapper,
+    odroidc2_timer->timer_irq_id = ps_irq_register(&ops.irq_ops, irqs[0], ltimer_handle_irq_wrapper,
                                                    &odroidc2_timer->callback_data);
     if (odroidc2_timer->timer_irq_id < 0) {
         destroy(ltimer->data);

--- a/libplatsupport/src/plat/polarfire/ltimer.c
+++ b/libplatsupport/src/plat/polarfire/ltimer.c
@@ -266,7 +266,7 @@ int ltimer_default_init(ltimer_t *ltimer, ps_io_ops_t ops, ltimer_callback_fn_t 
 
     irq_id = ps_irq_register(&ops.irq_ops,
                              irqs[TIMEOUT_TIMER],
-                             handle_irq_wrapper,
+                             ltimer_handle_irq_wrapper,
                              &timers->callback_data[TIMEOUT_TIMER]);
     if (irq_id < 0) {
         ZF_LOGE("Failed to register irq %i for MSTimer", irqs[TIMEOUT_TIMER].irq.number);
@@ -279,7 +279,7 @@ int ltimer_default_init(ltimer_t *ltimer, ps_io_ops_t ops, ltimer_callback_fn_t 
 
     irq_id = ps_irq_register(&ops.irq_ops,
                              irqs[TIMESTAMP_TIMER],
-                             handle_irq_wrapper,
+                             ltimer_handle_irq_wrapper,
                              &timers->callback_data[TIMESTAMP_TIMER]);
     if (irq_id < 0) {
         ZF_LOGE("Failed to register irq %i for MSTimer", irqs[TIMESTAMP_TIMER].irq.number);


### PR DESCRIPTION
Avoid using generic names, as this may cause name clashes.