### PR TITLE
cva6: add missing chardev include for dev_defn

### DIFF
--- a/libplatsupport/src/mach/cva6/serial.c
+++ b/libplatsupport/src/mach/cva6/serial.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <stdlib.h>
 #include <platsupport/serial.h>
 #include <platsupport/plat/serial.h>
-#include <string.h>
+
+#include "../../chardev.h"
 
 int uart_init(const struct dev_defn *defn,
               const ps_io_ops_t *ops,


### PR DESCRIPTION
This was previously giving a build warning regarding it only being defined within this file itself.

```c
/util_libs/libplatsupport/src/mach/cva6/serial.c:12:28: warning: ‘struct dev_defn’ declared inside parameter list will not be visible outside of this definition or declaration
   12 | int uart_init(const struct dev_defn *defn,
      |                            ^~~~~~~~
```