### PR TITLE
libplatsupport: export a config if no ltimer

### DIFF
--- a/libplatsupport/CMakeLists.txt
+++ b/libplatsupport/CMakeLists.txt
@@ -47,6 +47,13 @@ config_choice(
 
 mark_as_advanced(CLEAR LibPlatSupportX86ConsoleDevice LibPlatSupportLPTMRclock)
 
+# Some platforms don't have a platform timer.
+if(KernelPlatformCheshire)
+    config_set(LibPlatSupportNoPlatformLtimer LIB_PLAT_SUPPORT_NO_PLATFORM_LTIMER ON)
+else()
+    config_set(LibPlatSupportNoPlatformLtimer LIB_PLAT_SUPPORT_NO_PLATFORM_LTIMER OFF)
+endif()
+
 set(LibPlatSupportMach "")
 if(KernelPlatformRpi3 OR KernelPlatformRpi4)
     set(LibPlatSupportMach "bcm")

--- a/libplatsupport/include/platsupport/ltimer.h
+++ b/libplatsupport/include/platsupport/ltimer.h
@@ -9,6 +9,8 @@
 #include <platsupport/io.h>
 #include <platsupport/pmem.h>
 #include <platsupport/irq.h>
+#include <platsupport/gen_config.h>
+
 /**
  * This file provides the interface for an OS independant consisent timer interface.
  *
@@ -309,6 +311,7 @@ static inline void ltimer_us_delay(ltimer_t *timer, uint64_t microseconds) {
     ltimer_ns_delay(timer, microseconds * NS_IN_US);
 }
 
+#ifndef CONFIG_LIB_PLAT_SUPPORT_NO_PLATFORM_LTIMER
 /*
  * default init function -> platforms may provide multiple ltimers, but each
  * must have a default
@@ -323,3 +326,4 @@ int ltimer_default_init(ltimer_t *timer, ps_io_ops_t ops, ltimer_callback_fn_t c
  * the resources this ltimer needs without initialising the actual timer
  * drivers*/
 int ltimer_default_describe(ltimer_t *timer, ps_io_ops_t ops);
+#endif /* CONFIG_LIB_PLAT_SUPPORT_NO_PLATFORM_LTIMER*/

--- a/libplatsupport/include/platsupport/ltimer.h
+++ b/libplatsupport/include/platsupport/ltimer.h
@@ -164,13 +164,13 @@ static inline int ltimer_set_timeout(ltimer_t *timer, uint64_t nanoseconds, time
     }
 
     switch (type) {
-        case TIMEOUT_ABSOLUTE:
-        case TIMEOUT_PERIODIC:
-        case TIMEOUT_RELATIVE:
-            break;
-        default:
-            ZF_LOGE("Invalid timer type");
-            return EINVAL;
+    case TIMEOUT_ABSOLUTE:
+    case TIMEOUT_PERIODIC:
+    case TIMEOUT_RELATIVE:
+        break;
+    default:
+        ZF_LOGE("Invalid timer type");
+        return EINVAL;
     }
 
     return timer->set_timeout(timer->data, nanoseconds, type);
@@ -210,7 +210,7 @@ static inline int ltimer_get_nth_irq(ltimer_t *timer, size_t n, ps_irq_t *irq)
 static inline size_t ltimer_get_num_pmems(ltimer_t *timer)
 {
     if (timer->get_num_pmems == NULL) {
-         /* assume no physical memory required for this ltimer */
+        /* assume no physical memory required for this ltimer */
         return 0;
     }
 
@@ -284,7 +284,8 @@ static inline void ltimer_destroy(ltimer_t *timer)
 }
 
 /* Spinning delay functions */
-static inline void ltimer_ns_delay(ltimer_t *timer, uint64_t nanoseconds) {
+static inline void ltimer_ns_delay(ltimer_t *timer, uint64_t nanoseconds)
+{
     uint64_t start, end;
 
     int error = ltimer_get_time(timer, &start);
@@ -299,15 +300,18 @@ static inline void ltimer_ns_delay(ltimer_t *timer, uint64_t nanoseconds) {
     }
 }
 
-static inline void ltimer_s_delay(ltimer_t *timer, uint64_t seconds) {
+static inline void ltimer_s_delay(ltimer_t *timer, uint64_t seconds)
+{
     ltimer_ns_delay(timer, seconds * NS_IN_S);
 }
 
-static inline void ltimer_ms_delay(ltimer_t *timer, uint64_t milliseconds) {
+static inline void ltimer_ms_delay(ltimer_t *timer, uint64_t milliseconds)
+{
     ltimer_ns_delay(timer, milliseconds * NS_IN_MS);
 }
 
-static inline void ltimer_us_delay(ltimer_t *timer, uint64_t microseconds) {
+static inline void ltimer_us_delay(ltimer_t *timer, uint64_t microseconds)
+{
     ltimer_ns_delay(timer, microseconds * NS_IN_US);
 }
 


### PR DESCRIPTION
Previously this would be a linker error later.
Now this should hopefully make it clear by removing the prototypes and so should create a compile error (if flags are set correctly).

https://github.com/seL4/sel4bench/pull/55

Style failures are unrelated.