### PR TITLE
fix error implicit declaration of ltimer functions

### DIFF
--- a/libplatsupport/CMakeLists.txt
+++ b/libplatsupport/CMakeLists.txt
@@ -55,8 +55,11 @@ else()
 endif()
 
 config_option(
-    LibPlatSupportHaveTimer LIB_PLAT_SUPPORT_HAVE_TIMER
+    LibPlatSupportHaveTimer
+    LIB_PLAT_SUPPORT_HAVE_TIMER
     "Indicates that this platform has support for platform ltimers"
+    DEFAULT
+    ON
 )
 
 mark_as_advanced(LibPlatSupportHaveTimer)

--- a/libplatsupport/include/platsupport/ltimer.h
+++ b/libplatsupport/include/platsupport/ltimer.h
@@ -315,7 +315,7 @@ static inline void ltimer_us_delay(ltimer_t *timer, uint64_t microseconds)
     ltimer_ns_delay(timer, microseconds * NS_IN_US);
 }
 
-#ifdef CONFIG_LIB_PLAT_SUPPORT_HAVE_TIMER
+
 /*
  * default init function -> platforms may provide multiple ltimers, but each
  * must have a default
@@ -325,9 +325,15 @@ static inline void ltimer_us_delay(ltimer_t *timer, uint64_t microseconds)
  * with calling the ltimer functions inside the callback, the ltimer interface
  * functions are not reentrant.
  */
+#ifndef CONFIG_LIB_PLAT_SUPPORT_HAVE_TIMER
+__attribute__((error("no ltimer support for this platform")))
+#endif
 int ltimer_default_init(ltimer_t *timer, ps_io_ops_t ops, ltimer_callback_fn_t callback, void *callback_token);
+
 /* initialise the subset of functions required to get
  * the resources this ltimer needs without initialising the actual timer
  * drivers*/
+#ifndef CONFIG_LIB_PLAT_SUPPORT_HAVE_TIMER
+__attribute__((error("no ltimer support for this platform")))
+#endif
 int ltimer_default_describe(ltimer_t *timer, ps_io_ops_t ops);
-#endif /* CONFIG_LIB_PLAT_SUPPORT_HAVE_TIMER*/


### PR DESCRIPTION
Depends on https://github.com/seL4/util_libs/pull/197 to be merged first.

---

When a platform does not have `CONFIG_LIB_PLAT_SUPPORT_HAVE_TIMER` set,
we _were_ removing the declaration of `ltimer_default_init` since #193.
This was because there was also no definition and so caused a linker
error anyway, so I thought it wouldn't matter if it was defined or not.

This was fine for sel4bench uses, as we used `#ifdef` to remove the
callers of `ltimer_default_init` when there was no timer. However,
this broke sel4test: https://github.com/seL4/ci-actions/pull/411 for
Cheshire, as whilst sel4test had its CONFIG_HAVE_TIMER disabled, the
compiler still saw a call to `ltimer_default_init`:

    /sel4test/apps/sel4test-driver/src/main.c: In function ‘init_timer’:
    /sel4test/apps/sel4test-driver/src/main.c:180:17:
        error: implicit declaration of function ‘ltimer_default_init’

    180 | error = ltimer_default_init(&env.ltimer, env.ops, NULL, NULL);
        |         ^~~~~~~~~~~~~~~~~~~

The implementation of sel4test has:

    if (config_set(CONFIG_HAVE_TIMER)) {
        int error;

        error = ltimer_default_init(&env.ltimer, env.ops, NULL, NULL);
        ZF_LOGF_IF(error, "Failed to setup the timers");

        /* ... */
    }

When `ltimer_default_init` was still declared, the compiler would elide
the link to the `ltimer_default_init` symbol and so it would compile
fine, as `CONFIG_HAVE_TIMER`` is a compile-time constant.

This commit undoes this change, and leaves `ltimer_default_init` always
declare, unbreaking the sel4test builds when there is no timer.

In addition, we add `__attribute__((error(msg)))` to the declaration of
`ltimer_default_init` conditionally. This is documented by both GCC [1]
and by Clang [2] to only fire if it can't be elided with compile-time
optimisations. This is then fine for sel4bench (function call `#ifdef`
out entirely) and sel4test (`CONFIG_HAVE_TIMER` is compile-time known).

We were implicitly relying on the compiler to elide the link against
`ltimer_default_init` based on the compile-time constant anyway; so this
doesn't make the builds any more reliant on compiler optimisations.

As a demonstration of the diagnostic emitted if sel4test doesn't disable
the timer tests when the platform has no timer, the following error is
emitted during builds:

```
/sel4test/apps/sel4test-driver/src/main.c:180:17:
  error: call to ‘ltimer_default_init’ declared with attribute
    error: no ltimer support for this platform

  180 |  error = ltimer_default_init(&env.ltimer, env.ops, NULL, NULL);
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This should hopefully be much clearer than a link-time failure.

[1]: https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-error-function-attribute
[2]: https://clang.llvm.org/docs/AttributeReference.html#error-warning
