### PR TITLE
ltimer: indicate no support for more platforms

### DIFF
--- a/libplatsupport/CMakeLists.txt
+++ b/libplatsupport/CMakeLists.txt
@@ -48,7 +48,13 @@ config_choice(
 mark_as_advanced(CLEAR LibPlatSupportX86ConsoleDevice LibPlatSupportLPTMRclock)
 
 # Some platforms don't have a platform timer.
-if(KernelPlatformCheshire)
+if(
+    (KernelPlatformQEMUArmVirt AND NOT (KernelArmExportPCNTUser AND KernelArmExportPTMRUser))
+    OR KernelPlatformRocketchip
+    OR KernelPlatformRocketchipZCU102
+    OR KernelPlatformCheshire
+    OR (SIMULATION AND (KernelArchRiscV OR KernelArchARM))
+)
     set(LibPlatSupportHaveTimer OFF)
 else()
     set(LibPlatSupportHaveTimer ON)

--- a/libplatsupport/include/platsupport/ltimer.h
+++ b/libplatsupport/include/platsupport/ltimer.h
@@ -325,7 +325,7 @@ static inline void ltimer_us_delay(ltimer_t *timer, uint64_t microseconds)
  * with calling the ltimer functions inside the callback, the ltimer interface
  * functions are not reentrant.
  */
-#ifndef CONFIG_LIB_PLAT_SUPPORT_HAVE_TIMER
+#if !defined(CONFIG_LIB_PLAT_SUPPORT_HAVE_TIMER) && __has_attribute(error)
 __attribute__((error("no ltimer support for this platform")))
 #endif
 int ltimer_default_init(ltimer_t *timer, ps_io_ops_t ops, ltimer_callback_fn_t callback, void *callback_token);
@@ -333,7 +333,7 @@ int ltimer_default_init(ltimer_t *timer, ps_io_ops_t ops, ltimer_callback_fn_t c
 /* initialise the subset of functions required to get
  * the resources this ltimer needs without initialising the actual timer
  * drivers*/
-#ifndef CONFIG_LIB_PLAT_SUPPORT_HAVE_TIMER
+#if !defined(CONFIG_LIB_PLAT_SUPPORT_HAVE_TIMER) && __has_attribute(error)
 __attribute__((error("no ltimer support for this platform")))
 #endif
 int ltimer_default_describe(ltimer_t *timer, ps_io_ops_t ops);


### PR DESCRIPTION
These were taken from the sel4test Sel4testHaveTimer config option.

~~**Do not merge** until https://github.com/seL4/util_libs/pull/195 has been merged (as it will break sel4test for more platforms)~~ ok now