### PR TITLE
export LibPlatSupportHaveTimer instead of inverse

### DIFF
--- a/libplatsupport/CMakeLists.txt
+++ b/libplatsupport/CMakeLists.txt
@@ -49,10 +49,17 @@ mark_as_advanced(CLEAR LibPlatSupportX86ConsoleDevice LibPlatSupportLPTMRclock)
 
 # Some platforms don't have a platform timer.
 if(KernelPlatformCheshire)
-    config_set(LibPlatSupportNoPlatformLtimer LIB_PLAT_SUPPORT_NO_PLATFORM_LTIMER ON)
+    set(LibPlatSupportHaveTimer OFF)
 else()
-    config_set(LibPlatSupportNoPlatformLtimer LIB_PLAT_SUPPORT_NO_PLATFORM_LTIMER OFF)
+    set(LibPlatSupportHaveTimer ON)
 endif()
+
+config_option(
+    LibPlatSupportHaveTimer LIB_PLAT_SUPPORT_HAVE_TIMER
+    "Indicates that this platform has support for platform ltimers"
+)
+
+mark_as_advanced(LibPlatSupportHaveTimer)
 
 set(LibPlatSupportMach "")
 if(KernelPlatformRpi3 OR KernelPlatformRpi4)

--- a/libplatsupport/include/platsupport/ltimer.h
+++ b/libplatsupport/include/platsupport/ltimer.h
@@ -315,7 +315,7 @@ static inline void ltimer_us_delay(ltimer_t *timer, uint64_t microseconds)
     ltimer_ns_delay(timer, microseconds * NS_IN_US);
 }
 
-#ifndef CONFIG_LIB_PLAT_SUPPORT_NO_PLATFORM_LTIMER
+#ifdef CONFIG_LIB_PLAT_SUPPORT_HAVE_TIMER
 /*
  * default init function -> platforms may provide multiple ltimers, but each
  * must have a default
@@ -330,4 +330,4 @@ int ltimer_default_init(ltimer_t *timer, ps_io_ops_t ops, ltimer_callback_fn_t c
  * the resources this ltimer needs without initialising the actual timer
  * drivers*/
 int ltimer_default_describe(ltimer_t *timer, ps_io_ops_t ops);
-#endif /* CONFIG_LIB_PLAT_SUPPORT_NO_PLATFORM_LTIMER*/
+#endif /* CONFIG_LIB_PLAT_SUPPORT_HAVE_TIMER*/


### PR DESCRIPTION
As suggested by Indan to be clearer to understand. https://github.com/seL4/util_libs/pull/196#issuecomment-2918974119

Needs to be merged **with** the corresponding PRs to seL4_libs (https://github.com/seL4/seL4_libs/pull/104) and sel4bench (https://github.com/seL4/sel4bench/pull/

Test with: https://github.com/seL4/seL4_libs/pull/104
Test with: https://github.com/seL4/sel4bench/pull/58