### PR TITLE
ltimer: enable timer for QEMU Arm arch timers

### DIFF
--- a/libplatsupport/CMakeLists.txt
+++ b/libplatsupport/CMakeLists.txt
@@ -48,9 +48,14 @@ config_choice(
 mark_as_advanced(CLEAR LibPlatSupportX86ConsoleDevice LibPlatSupportLPTMRclock)
 
 # Some platforms don't have a platform timer.
-if(
-    (KernelPlatformQEMUArmVirt AND NOT (KernelArmExportPCNTUser AND KernelArmExportPTMRUser))
-    OR KernelPlatformRocketchip
+if(KernelPlatformQEMUArmVirt)
+    if(KernelArmExportPCNTUser AND KernelArmExportPTMRUser)
+        set(LibPlatSupportHaveTimer ON)
+    else()
+        set(LibPlatSupportHaveTimer OFF)
+    endif()
+elseif(
+    KernelPlatformRocketchip
     OR KernelPlatformRocketchipZCU102
     OR KernelPlatformCheshire
     OR (SIMULATION AND (KernelArchRiscV OR KernelArchARM))


### PR DESCRIPTION
The if statements were not strictly equivalent and broke the camkes timer component builds:

https://github.com/seL4/util_libs/pull/196/files#r2178857087

Ref: https://github.com/seL4/sel4test/pull/142