### PR TITLE
Add Support for Banana Pi BPI-F3

### DIFF
--- a/libplatsupport/CMakeLists.txt
+++ b/libplatsupport/CMakeLists.txt
@@ -48,12 +48,11 @@ config_choice(
 mark_as_advanced(CLEAR LibPlatSupportX86ConsoleDevice LibPlatSupportLPTMRclock)
 
 # Some platforms don't have a platform timer.
-if(
-    (KernelPlatformQEMUArmVirt AND NOT (KernelArmExportPCNTUser AND KernelArmExportPTMRUser))
-    OR KernelPlatformRocketchip
-    OR KernelPlatformRocketchipZCU102
-    OR KernelPlatformCheshire
-    OR (SIMULATION AND (KernelArchRiscV OR KernelArchARM))
+if((KernelPlatformQEMUArmVirt AND NOT (KernelArmExportPCNTUser AND KernelArmExportPTMRUser))
+   OR KernelPlatformRocketchip
+   OR KernelPlatformRocketchipZCU102
+   OR KernelPlatformCheshire
+   OR (SIMULATION AND (KernelArchRiscV OR KernelArchARM))
 )
     set(LibPlatSupportHaveTimer OFF)
 else()
@@ -61,11 +60,8 @@ else()
 endif()
 
 config_option(
-    LibPlatSupportHaveTimer
-    LIB_PLAT_SUPPORT_HAVE_TIMER
-    "Indicates that this platform has support for platform ltimers"
-    DEFAULT
-    ON
+    LibPlatSupportHaveTimer LIB_PLAT_SUPPORT_HAVE_TIMER
+    "Indicates that this platform has support for platform ltimers" DEFAULT ON
 )
 
 mark_as_advanced(LibPlatSupportHaveTimer)
@@ -77,18 +73,14 @@ elseif(KernelPlatformCheshire OR KernelPlatformAriane)
     set(LibPlatSupportMach "cva6")
 elseif(KernelPlatformHifiveP550)
     set(LibPlatSupportMach "eswin")
+elseif(KernelPlatformBananapiF3)
+    set(LibPlatSupportMach "spacemit")
 elseif(NOT ${KernelArmMach} STREQUAL "")
     # falling back to kernel settings is done to keep legacy compatibility
     set(LibPlatSupportMach "${KernelArmMach}")
 endif()
 
-file(
-    GLOB
-        deps
-        src/plat/${KernelPlatform}/*.c
-        src/*.c
-        src/plat/${KernelPlatform}/acpi/*.c
-)
+file(GLOB deps src/plat/${KernelPlatform}/*.c src/*.c src/plat/${KernelPlatform}/acpi/*.c)
 
 if(NOT ${LibPlatSupportMach} STREQUAL "")
     file(GLOB lib_deps "src/mach/${LibPlatSupportMach}/*.c")
@@ -107,10 +99,8 @@ if(KernelArchARM)
     list(APPEND deps src/arch/arm/irqchip/gicv3.c)
     list(APPEND deps src/arch/arm/irqchip/omap3.c)
     # Link the IRQ chip parser modules
-    list(
-        APPEND
-            irqchip_modules
-            "-Wl,--undefined=arm_gic_ptr,--undefined=tegra_ictlr_ptr,--undefined=arm_gicv3_ptr,\
+    list(APPEND irqchip_modules
+         "-Wl,--undefined=arm_gic_ptr,--undefined=tegra_ictlr_ptr,--undefined=arm_gicv3_ptr,\
 --undefined=fsl_avic_ptr,--undefined=ti_omap3_ptr"
     )
 elseif(KernelArchX86)
@@ -123,7 +113,10 @@ else()
     message(FATAL_ERROR "Unsupported KernelArch '${KernelArch}'")
 endif()
 
-if(KernelPlatformQEMUArmVirt OR KernelPlatformQuartz64 OR KernelPlatformIMX93)
+if(KernelPlatformQEMUArmVirt
+   OR KernelPlatformQuartz64
+   OR KernelPlatformIMX93
+)
     if(KernelArmExportPCNTUser AND KernelArmExportPTMRUser)
         list(APPEND deps src/arch/arm/generic_ltimer.c)
     endif()
@@ -131,7 +124,11 @@ endif()
 
 if(KernelPlatformExynos5422)
     list(APPEND deps src/mach/${LibPlatSupportMach}/clock/exynos_5422_clock.c)
-elseif(KernelPlatformExynos4 OR KernelPlatformExynos5410 OR KernelPlatformExynos5250)
+elseif(
+    KernelPlatformExynos4
+    OR KernelPlatformExynos5410
+    OR KernelPlatformExynos5250
+)
     list(APPEND deps src/mach/${LibPlatSupportMach}/clock/exynos_common_clock.c)
 endif()
 
@@ -139,18 +136,20 @@ if(KernelPlatImx6 OR KernelPlatformImx7Sabre)
     list(APPEND deps src/mach/${LibPlatSupportMach}/epit/epit.c)
 endif()
 
-if(
-    KernelPlatImx6
-    OR KernelPlatformImx7Sabre
-    OR KernelPlatformImx8mq-evk
-    OR KernelPlatformImx8mm-evk
-    OR KernelPlatformImx8mp-evk
-    OR KernelPlatformMaaxboard
+if(KernelPlatImx6
+   OR KernelPlatformImx7Sabre
+   OR KernelPlatformImx8mq-evk
+   OR KernelPlatformImx8mm-evk
+   OR KernelPlatformImx8mp-evk
+   OR KernelPlatformMaaxboard
 )
     list(APPEND deps src/mach/${LibPlatSupportMach}/serial/serial.c)
 endif()
 
-if(KernelPlatImx8mq OR KernelPlatformImx8mm-evk OR KernelPlatformImx8mp-evk)
+if(KernelPlatImx8mq
+   OR KernelPlatformImx8mm-evk
+   OR KernelPlatformImx8mp-evk
+)
     list(APPEND deps src/plat/imx8m/chardev.c)
     # There's no clock driver at the moment, but this is to allow the
     # libethdrivers to build for imx8mq
@@ -159,10 +158,7 @@ endif()
 
 if(KernelPlatPC99)
     set_source_files_properties(
-        src/plat/pc99/keyboard_vkey.c
-        PROPERTIES
-        COMPILE_FLAGS
-        -Wno-initializer-overrides
+        src/plat/pc99/keyboard_vkey.c PROPERTIES COMPILE_FLAGS -Wno-initializer-overrides
     )
 endif()
 
@@ -172,7 +168,10 @@ add_config_library(platsupport "${configure_string}")
 
 add_library(platsupport EXCLUDE_FROM_ALL ${deps})
 
-if(KernelPlatImx8mq OR KernelPlatformImx8mm-evk OR KernelPlatformImx8mp-evk)
+if(KernelPlatImx8mq
+   OR KernelPlatformImx8mm-evk
+   OR KernelPlatformImx8mp-evk
+)
     if(KernelPlatformImx8mp-evk)
         # For the imx8mp, the DTS is in a different format compared to those of
         # the imx8mm and imx8mq, there are some constants in the headers that
@@ -200,12 +199,8 @@ if("${KernelSel4Arch}" STREQUAL "arm_hyp")
 endif()
 
 target_include_directories(
-    platsupport
-    PUBLIC
-        include
-        plat_include/${KernelPlatform}
-        sel4_arch_include/${_inc_folder_KernelSel4Arch}
-        arch_include/${KernelArch}
+    platsupport PUBLIC include plat_include/${KernelPlatform}
+                       sel4_arch_include/${_inc_folder_KernelSel4Arch} arch_include/${KernelArch}
 )
 
 target_link_libraries(

--- a/libplatsupport/mach_include/spacemit/platsupport/mach/timer.h
+++ b/libplatsupport/mach_include/spacemit/platsupport/mach/timer.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025, 10xEngineers
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+#pragma once
+
+/* The K1 SoC has multiple timers, the 'Timer1' peripheral is used
+ * by this driver. Each timer peripheral consists of three individual
+ * counters/timers, confusingly named Timer 0, Timer 1 and Timer 2.
+ * Below Timer 0 is called TIMER0 and is used as a counter and Timer 1
+ * is called TIMER1 and used for timeouts.
+ * K1 SoC spec : https://developer.spacemit.com/documentation?token=AZsXwVrqaisaDGkUqMWcNuMVnPb
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+#define SPACEMIT_TIMER_BASE      0xD4014000
+#define APB_CLK_BASE             0xD4015000
+#define SPACEMIT_TIMER_SIZE      0x2000u
+#define SPACEMIT_TIMER0_IRQ      23u // timer0_1_irq: Timer 0 IRQ of Timer1
+#define SPACEMIT_TIMER1_IRQ      24u // timer0_2_irq: Timer 0 IRQ of Timer2
+#define SLOW_CLOCK false
+
+#if SLOW_CLOCK
+#define SPACEMIT_TIMER_TICKS_PER_SECOND  32768u
+#define K1_TCCR_CS0_VALUE                0x1u   /* slow clock */
+#else
+#define SPACEMIT_TIMER_TICKS_PER_SECOND  12800000u
+#define K1_TCCR_CS0_VALUE                0x0u   /* fast clock */
+#endif
+
+#define SPACEMIT_NUM_TIMERS 3
+#define SPACEMIT_TIMER_MAX_TICKS UINT32_MAX
+#define APBC_TIMERx_CLK_RST_OFFSET  0x34u
+#define SPACEMIT_TIMERS_CNT_OFFSET  0x90u
+
+typedef struct {
+    uint32_t tcer;         // Timer Count Enable Register
+    uint32_t tcmr;         // Timer Count Mode Register
+    uint32_t tcrr;         // Timer Count Restart Register
+    uint32_t tccr;         // Timer Clock Control Register
+
+    uint32_t tmr[3][4];    // Timer Match Register (TMRx)
+    uint32_t tplvr[4];     // Timer Preload Value Register (TPLVRx)
+    uint32_t tplcr[4];     // Timer Preload Control Register (TPLCRx)
+
+    uint32_t tier[4];      // Timer Interrupt Enable Register (TIERx)
+    uint32_t ticr[4];      // Timer Interrupt Clear Register (TICLRx)
+    uint32_t tsr[4];       // Timer Status Register (TSRx)
+
+    uint32_t tcnt[4];      // Timer Count Register (TCRx)
+} spacemit_timer_regs_t;
+static_assert(offsetof(spacemit_timer_regs_t, tcnt) == SPACEMIT_TIMERS_CNT_OFFSET,
+              "struct spacemit_timer_regs_t has incorrect layout");
+
+typedef struct {
+    volatile spacemit_timer_regs_t *regs;
+    uint8_t  timer_n;
+    uint32_t value_h;
+    uint32_t *vaddr;
+} spacemit_timer_t;
+
+void spacemit_timer_enable(spacemit_timer_t *timer);
+void spacemit_timer_disable(spacemit_timer_t *timer);
+uint64_t spacemit_timer_get_time(spacemit_timer_t *timer);
+void spacemit_timer_reset(spacemit_timer_t *timer);
+int spacemit_timer_set_timeout(spacemit_timer_t *timer, uint64_t ns, bool is_periodic);
+void spacemit_timer_disable_all(void *vaddr);
+void spacemit_timer_init(spacemit_timer_t *timer, void *vaddr, uint64_t channel);

--- a/libplatsupport/plat_include/bananapi-f3/platsupport/plat/serial.h
+++ b/libplatsupport/plat_include/bananapi-f3/platsupport/plat/serial.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025, 10xEngineers
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+#include <autoconf.h>
+
+/* The K1 SoC provides 10 UARTs (UART0–UART9), all are 16550A and 167502 compatible.
+ * Below UART refers to UART0, which is used as the serial console.
+ */
+
+enum chardev_id {
+    UART0,
+    PS_SERIAL_DEFAULT = UART0
+};
+
+#define UART0_PADDR 0xd4017000
+#define UART0_IRQ 42
+
+#define DEFAULT_SERIAL_PADDR UART0_PADDR
+#define DEFAULT_SERIAL_INTERRUPT UART0_IRQ

--- a/libplatsupport/src/mach/spacemit/chardev.c
+++ b/libplatsupport/src/mach/spacemit/chardev.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025, 10xEngineers
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "../../chardev.h"
+#include "../../common.h"
+#include <utils/util.h>
+
+static const int uart0_irqs[] = {UART0_IRQ, -1};
+
+/*
+ * Despite each UART being 0x100 in size (according to the device tree) we
+ * only need to map in the first page for the driver to function.
+ */
+#define UART_DEFN(devid) {          \
+    .id      = UART##devid,    \
+    .paddr   = UART##devid##_PADDR, \
+    .size    = BIT(12),             \
+    .irqs    = uart##devid##_irqs,  \
+    .init_fn = &uart_init           \
+}
+
+const struct dev_defn dev_defn[] = {
+    UART_DEFN(0),
+};
+
+struct ps_chardevice *
+ps_cdev_init(enum chardev_id id, const ps_io_ops_t *o, struct ps_chardevice *d)
+{
+    unsigned int i;
+    for (i = 0; i < ARRAY_SIZE(dev_defn); i++) {
+        if (dev_defn[i].id == id) {
+            return (dev_defn[i].init_fn(dev_defn + i, o, d)) ? NULL : d;
+        }
+    }
+    return NULL;
+}

--- a/libplatsupport/src/mach/spacemit/ltimer.c
+++ b/libplatsupport/src/mach/spacemit/ltimer.c
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2025, 10xEngineers
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <platsupport/io.h>
+#include <platsupport/ltimer.h>
+#include <platsupport/mach/timer.h>
+#include <platsupport/pmem.h>
+#include <platsupport/timer.h>
+#include <utils/io.h>
+#include <utils/util.h>
+
+#include "../../ltimer.h"
+
+enum {
+    COUNTER_TIMER,
+    TIMEOUT_TIMER,
+    NUM_TIMERS
+};
+
+typedef struct {
+    void *vaddr;
+    spacemit_timer_t timer[NUM_TIMERS];
+    irq_id_t irq_id[NUM_TIMERS];
+    timer_callback_data_t callback_data[NUM_TIMERS];
+    ltimer_callback_fn_t user_callback;
+    void *user_callback_token;
+    ps_io_ops_t ops;
+} spacemit_ltimer_t;
+
+static ps_irq_t irqs[] = {
+    {
+        .type = PS_INTERRUPT,
+        .trigger.number = SPACEMIT_TIMER0_IRQ,
+    },
+    {
+        .type = PS_INTERRUPT,
+        .trigger.number = SPACEMIT_TIMER1_IRQ,
+    },
+};
+
+static pmem_region_t pmems[] = {
+    {
+        .type = PMEM_TYPE_DEVICE,
+        .base_addr = SPACEMIT_TIMER_BASE,
+        .length = SPACEMIT_TIMER_SIZE,
+    },
+};
+
+#define NUM_IRQS ARRAY_SIZE(irqs)
+#define NUM_PMEMS ARRAY_SIZE(pmems)
+
+static size_t get_num_irqs(void *data)
+{
+    return NUM_IRQS;
+}
+
+static int get_nth_irq(void *data, size_t n, ps_irq_t *irq)
+{
+    assert(n < NUM_IRQS);
+    assert(irq);
+
+    *irq = irqs[n];
+    return 0;
+}
+
+static size_t get_num_pmems(void *data)
+{
+    return NUM_PMEMS;
+}
+
+static int get_nth_pmem(void *data, size_t n, pmem_region_t *paddr)
+{
+    assert(n < NUM_PMEMS);
+    assert(paddr);
+
+    *paddr = pmems[n];
+    return 0;
+}
+
+static int ltimer_handle_irq(void *data, ps_irq_t *irq)
+{
+    assert(data);
+    assert(irq);
+
+    spacemit_ltimer_t *timers = (spacemit_ltimer_t *)data;
+    long irq_number = irq->irq.number;
+    ltimer_event_t event;
+
+    if (irq_number != irqs[0].irq.number && irq_number != irqs[1].irq.number) {
+        ZF_LOGE("Invalid IRQ number %ld received.", irq_number);
+        return EINVAL;
+    }
+
+    /* Check Timer Status reg */
+    uint8_t int_status = timers->timer[COUNTER_TIMER].regs->tsr[COUNTER_TIMER];
+    if (int_status & 0x1) {
+        /* Ack the Interrupt / clear the Interrupt*/
+        timers->timer[COUNTER_TIMER].regs->ticr[COUNTER_TIMER] |= (1u << 0);
+        timers->timer[COUNTER_TIMER].value_h += 1;
+        event = LTIMER_OVERFLOW_EVENT;
+    }
+
+    if (timers->user_callback) {
+        timers->user_callback(timers->user_callback_token, event);
+    }
+
+    int_status = timers->timer[TIMEOUT_TIMER].regs->tsr[TIMEOUT_TIMER];
+    if (int_status & 0x1) {
+        /* Ack the Interrupt / clear the Interrupt*/
+        timers->timer[TIMEOUT_TIMER].regs->ticr[TIMEOUT_TIMER] |= (1u << 0);
+        timers->timer[TIMEOUT_TIMER].value_h += 1;
+        event = LTIMER_TIMEOUT_EVENT;
+    }
+
+    if (timers->user_callback) {
+        timers->user_callback(timers->user_callback_token, event);
+    }
+
+    return 0;
+}
+
+static int get_time(void *data, uint64_t *time)
+{
+    assert(data);
+    assert(time);
+
+    spacemit_ltimer_t *timers = (spacemit_ltimer_t *)data;
+    *time = spacemit_timer_get_time(&timers->timer[COUNTER_TIMER]);
+
+    return 0;
+}
+
+static int set_timeout(void *data, uint64_t ns, timeout_type_t type)
+{
+    assert(data);
+    spacemit_ltimer_t *timers = (spacemit_ltimer_t *)data;
+
+    switch (type) {
+    case TIMEOUT_ABSOLUTE: {
+        uint64_t time = spacemit_timer_get_time(&timers->timer[COUNTER_TIMER]);
+        if (time >= ns) {
+            ZF_LOGD("Requested time %"PRIu64" earlier than current time %"PRIu64, ns, time);
+            return ETIME;
+        }
+        return spacemit_timer_set_timeout(&timers->timer[TIMEOUT_TIMER], ns - time, false);
+    }
+    case TIMEOUT_RELATIVE:
+        return spacemit_timer_set_timeout(&timers->timer[TIMEOUT_TIMER], ns, false);
+    case TIMEOUT_PERIODIC:
+        return spacemit_timer_set_timeout(&timers->timer[TIMEOUT_TIMER], ns, true);
+    }
+
+    return EINVAL;
+}
+
+static int reset(void *data)
+{
+    assert(data);
+    spacemit_ltimer_t *timers = (spacemit_ltimer_t *)data;
+
+    spacemit_timer_disable(&timers->timer[COUNTER_TIMER]);
+    spacemit_timer_reset(&timers->timer[COUNTER_TIMER]);
+    spacemit_timer_enable(&timers->timer[COUNTER_TIMER]);
+
+    spacemit_timer_disable(&timers->timer[TIMEOUT_TIMER]);
+    spacemit_timer_reset(&timers->timer[TIMEOUT_TIMER]);
+
+    return 0;
+}
+
+static void destroy(void *data)
+{
+    assert(data);
+    spacemit_ltimer_t *timers = (spacemit_ltimer_t *)data;
+    int error;
+
+    spacemit_timer_disable(&timers->timer[COUNTER_TIMER]);
+    spacemit_timer_disable(&timers->timer[TIMEOUT_TIMER]);
+
+    ps_pmem_unmap(&timers->ops, pmems[0], timers->timer[COUNTER_TIMER].vaddr);
+
+    error = ps_irq_unregister(&timers->ops.irq_ops, timers->irq_id[COUNTER_TIMER]);
+    ZF_LOGE_IF(error, "Failed to uregister counter timer IRQ");
+
+    error = ps_irq_unregister(&timers->ops.irq_ops, timers->irq_id[TIMEOUT_TIMER]);
+    ZF_LOGE_IF(error, "Failed to uregister timeout timer IRQ");
+
+    error = ps_free(&timers->ops.malloc_ops, sizeof(*timers), timers);
+    ZF_LOGE_IF(error, "Failed to free device struct memory");
+}
+
+int ltimer_default_init(ltimer_t *ltimer,
+                        ps_io_ops_t ops,
+                        ltimer_callback_fn_t callback,
+                        void *callback_token)
+{
+    assert(ltimer);
+
+    ltimer->get_num_irqs = get_num_irqs;
+    ltimer->get_nth_irq = get_nth_irq;
+    ltimer->get_num_pmems = get_num_pmems;
+    ltimer->get_nth_pmem = get_nth_pmem;
+    ltimer->get_time = get_time;
+    ltimer->set_timeout = set_timeout;
+    ltimer->reset = reset;
+    ltimer->destroy = destroy;
+
+    int error = ps_calloc(&ops.malloc_ops, 1, sizeof(spacemit_ltimer_t), &ltimer->data);
+    if (error) {
+        ZF_LOGE("Memory allocation failed with error %d", error);
+        return error;
+    }
+    spacemit_ltimer_t *timers = ltimer->data;
+
+    timers->ops = ops;
+    timers->user_callback = callback;
+    timers->user_callback_token = callback_token;
+
+    timers->vaddr = ps_pmem_map(&ops, pmems[0], false, PS_MEM_NORMAL);
+    if (timers->vaddr == NULL) {
+        ZF_LOGE("Unable to map physical memory at 0x%"PRIx64" length 0x%"PRIx64,
+                pmems[0].base_addr,
+                pmems[0].length);
+        destroy(ltimer->data);
+        return EINVAL;
+    }
+
+    for (size_t i = 0; i < NUM_TIMERS; i++) {
+
+        timers->callback_data[i].ltimer = ltimer;
+        timers->callback_data[i].irq = &irqs[i];
+        timers->callback_data[i].irq_handler = ltimer_handle_irq;
+
+        timers->irq_id[i] = ps_irq_register(&ops.irq_ops,
+                                            irqs[i],
+                                            handle_irq_wrapper,
+                                            &timers->callback_data[i]);
+        if (timers->irq_id[i] < 0) {
+            destroy(ltimer->data);
+            return EIO;
+        }
+
+        /*Timers share same region*/
+        timers->timer[i].vaddr = timers->vaddr;
+    }
+    spacemit_timer_disable_all(timers->vaddr);
+
+    spacemit_timer_init(&timers->timer[COUNTER_TIMER], timers->timer[COUNTER_TIMER].vaddr, COUNTER_TIMER);
+    spacemit_timer_enable(&timers->timer[COUNTER_TIMER]);
+
+    spacemit_timer_init(&timers->timer[TIMEOUT_TIMER], timers->timer[TIMEOUT_TIMER].vaddr, TIMEOUT_TIMER);
+    return 0;
+}

--- a/libplatsupport/src/mach/spacemit/serial.c
+++ b/libplatsupport/src/mach/spacemit/serial.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025, 10xEngineers
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <platsupport/serial.h>
+#include <platsupport/plat/serial.h>
+#include "../../chardev.h"
+
+#define UART_THR 0x00         /* UART Transmit Holding Register */
+#define UART_LSR 0x14         /* UART Line Status Register */
+
+#define UART_LSR_TDRQ  BIT(5) /* Transmit Data Request */
+
+#define REG_PTR(base, off)     ((volatile uint32_t *)((base) + (off)))
+
+int uart_getchar(ps_chardevice_t *d)
+{
+    while ((*REG_PTR(d->vaddr, UART_LSR) & BIT(0)));
+    return *REG_PTR(d->vaddr, UART_THR);
+}
+
+int uart_putchar(ps_chardevice_t *d, int c)
+{
+    if (c == '\n' && (d->flags & SERIAL_AUTO_CR)) {
+        uart_putchar(d, '\r');
+    }
+
+    while ((*REG_PTR(d->vaddr, UART_LSR) & UART_LSR_TDRQ) == 0);
+
+    /* Add character to the buffer. */
+    *REG_PTR(d->vaddr, UART_THR) = c;
+
+    return c;
+}
+
+static void uart_handle_irq(ps_chardevice_t *dev)
+{
+    /*
+     * This is currently only called when received data is available on the device.
+     * The interrupt will be acked to the device on the next read to the device.
+     * There's nothing else we need to do here.
+     */
+}
+
+int uart_init(const struct dev_defn *defn,
+              const ps_io_ops_t *ops,
+              ps_chardevice_t *dev)
+{
+    memset(dev, 0, sizeof(*dev));
+    void *vaddr = chardev_map(defn, ops);
+    if (vaddr == NULL) {
+        ZF_LOGE("Unable to map chardev");
+        return -1;
+    }
+
+    /* Set up all the  device properties. */
+    dev->id         = defn->id;
+    dev->vaddr      = vaddr;
+    dev->read       = &uart_read;
+    dev->write      = &uart_write;
+    dev->handle_irq = &uart_handle_irq;
+    dev->irqs       = defn->irqs;
+    dev->ioops      = *ops;
+    dev->flags      = SERIAL_AUTO_CR;
+
+    return 0;
+}

--- a/libplatsupport/src/mach/spacemit/timer.c
+++ b/libplatsupport/src/mach/spacemit/timer.c
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2025, 10xEngineers
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <inttypes.h>
+#include <platsupport/mach/timer.h>
+#include <stdint.h>
+#include <utils/util.h>
+
+#define MAX_TIMEOUT_NS (SPACEMIT_TIMER_MAX_TICKS * (NS_IN_S / SPACEMIT_TIMER_TICKS_PER_SECOND))
+
+static void spacemit_timer_enable_clocks(spacemit_timer_t *timer)
+{
+    volatile uint32_t *base   = (volatile uint32_t *)((uint8_t *)timer->vaddr + 0x1000); // APB_CLK_BASE
+    uint32_t offset           = APBC_TIMERx_CLK_RST_OFFSET / sizeof(uint32_t);
+    uint32_t clk_select_shift = 0x4;
+    uint32_t init_value       = 0x0;
+
+    init_value |= (1 << 0);
+    init_value |= (1 << 1);
+    init_value |= K1_TCCR_CS0_VALUE << clk_select_shift;
+
+    base[offset] = init_value;
+}
+
+void spacemit_timer_enable(spacemit_timer_t *timer)
+{
+    assert(timer);
+    assert(timer->regs);
+    assert(timer->timer_n < SPACEMIT_NUM_TIMERS);
+
+    timer->regs->tcer  |= (1u << timer->timer_n);
+}
+
+
+void spacemit_timer_disable(spacemit_timer_t *timer)
+{
+    assert(timer);
+    assert(timer->regs);
+
+    timer->regs->tcer  &= ~(1u << timer->timer_n);
+}
+
+uint64_t spacemit_timer_get_time(spacemit_timer_t *timer)
+{
+    assert(timer);
+    assert(timer->regs);
+
+    uint8_t n = timer->timer_n;
+    /* the timer counter counts up */
+    uint64_t value_l = (uint64_t)timer->regs->tcnt[n];
+    uint64_t value_h = (uint64_t)timer->value_h;
+
+    /* Include unhandled interrupt in value_h */
+    uint32_t status = timer->regs->tsr[n];
+    if (status & 0x1) {
+        value_h += 1;
+    }
+
+    uint64_t value_ticks = (value_h << 32) | value_l;
+
+    /* convert from ticks to nanoseconds */
+    uint64_t whole_seconds = value_ticks / SPACEMIT_TIMER_TICKS_PER_SECOND;
+    uint64_t subsecond_ticks = value_ticks % SPACEMIT_TIMER_TICKS_PER_SECOND;
+    uint64_t subsecond_ns =
+        (subsecond_ticks * NS_IN_S) / SPACEMIT_TIMER_TICKS_PER_SECOND;
+    uint64_t value_ns = whole_seconds * NS_IN_S + subsecond_ns;
+
+    return value_ns;
+}
+
+void spacemit_timer_reset(spacemit_timer_t *timer)
+{
+    assert(timer);
+    assert(timer->regs);
+
+    spacemit_timer_disable(timer);
+    timer->value_h = 0;
+    uint8_t n = timer->timer_n;
+
+    /* Reset match register */
+    timer->regs->tmr[n][0] = (uint32_t)(SPACEMIT_TIMER_MAX_TICKS);
+}
+
+int spacemit_timer_set_timeout(spacemit_timer_t *timer, uint64_t ns, bool is_periodic)
+{
+    spacemit_timer_disable(timer);
+    timer->value_h = 0;
+    uint8_t n = timer->timer_n;
+
+    if (is_periodic) {
+        timer->regs->tcmr &= ~(1u << n);      /* Periodic mode */
+    } else {
+        timer->regs->tcmr |= (1u << n);       /* Free-run mode */
+    }
+
+    /* convert from nanoseconds to ticks */
+    uint64_t ticks_whole_seconds = (ns / NS_IN_S) * SPACEMIT_TIMER_TICKS_PER_SECOND;
+    uint64_t ticks_remainder = (ns % NS_IN_S) * SPACEMIT_TIMER_TICKS_PER_SECOND / NS_IN_S;
+    uint64_t num_ticks = ticks_whole_seconds + ticks_remainder;
+
+    if (num_ticks > SPACEMIT_TIMER_MAX_TICKS) {
+        ZF_LOGE("Requested timeout of %"PRIu64" ns exceeds hardware limit of %"PRIu64" ns",
+                ns,
+                MAX_TIMEOUT_NS);
+        return -EINVAL;
+    }
+
+    /* Set the match register and enable interrupt */
+    timer->regs->tmr[n][0] = (uint32_t)(num_ticks);
+    timer->regs->tier[n]   |= (1u << 0);
+
+    spacemit_timer_enable(timer);
+
+    return 0;
+}
+
+
+void spacemit_timer_disable_all(void *vaddr)
+{
+    assert(vaddr);
+    volatile spacemit_timer_regs_t *regs = vaddr;
+    regs->tcer     &= ~(0x7u);
+
+}
+
+void spacemit_timer_init(spacemit_timer_t *timer, void *vaddr, size_t n)
+{
+    assert(timer);
+    assert(vaddr);
+    assert(n < SPACEMIT_NUM_TIMERS);
+
+    timer->vaddr = (uint32_t *)vaddr;
+
+    spacemit_timer_enable_clocks(timer);
+    timer->regs           = vaddr;  /* all timers share same base addr */
+    timer->timer_n        = n;
+    timer->value_h        = 0;
+    timer->regs->tcer     &= ~(1u << n);
+    timer->regs->tcmr     |= (1u << n);       /* Free-run mode */
+
+    uint32_t clock_ctrl   = timer->regs->tccr;
+    clock_ctrl            &= ~(3U << (n * 2));      /* Clear existing bits */
+    clock_ctrl            |= (0x0 << (n * 2));      /* Set to fast clock (12.8 MHz) */
+    timer->regs->tccr     = clock_ctrl;
+
+    /* Set the match register and enable interrupt */
+    timer->regs->tmr[n][0] = (uint32_t)(SPACEMIT_TIMER_MAX_TICKS);
+    timer->regs->tier[n]  |= (1u << 0);
+}


### PR DESCRIPTION
related to https://github.com/seL4/seL4/pull/1535

This driver is based on the implementations in [PR #167](https://github.com/seL4/util_libs/pull/167) and [PR #190](https://github.com/seL4/util_libs/pull/190), with necessary updates, such as address and configuration changes applied according to the current DTS for this platform added here https://github.com/seL4/seL4/blob/772179e4e639fec1c48a01c69ea6cea144cab02a/tools/dts/bananapi-f3.dts